### PR TITLE
Fix DB sidebar text color

### DIFF
--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -99,3 +99,14 @@
     font-size: 13px;
     line-height: 1.4em;
 }
+
+/* Ensure DB sidebar sections remain readable */
+#copilot-sidebar .white-box {
+    background-color: #fff;
+    color: #000 !important;
+}
+
+/* inherit text color for nested elements */
+#copilot-sidebar .white-box * {
+    color: inherit !important;
+}


### PR DESCRIPTION
## Summary
- ensure DB sidebar text is black on white boxes

## Testing
- `npm test` *(fails: no `package.json`)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6849203466c88326b2660085690d74f2