### PR TITLE
Improve RA subscription status extraction

### DIFF
--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -83,6 +83,23 @@
         return rows[0] || null;
     }
 
+    // Obtiene el estatus de subscripción del Registered Agent desde la pestaña
+    // de suscripciones. Busca la fila correspondiente y retorna el valor de la
+    // columna de estatus (p.ej. "Active" o "Inactive").
+    function getAgentSubscriptionStatus() {
+        const rows = document.querySelectorAll('#vsubscriptions .table-list-of-subs tbody tr');
+        for (const row of rows) {
+            const cells = row.querySelectorAll('td');
+            if (cells.length >= 3) {
+                const planName = cells[1].innerText || '';
+                if (/registered agent/i.test(planName)) {
+                    return cells[2].innerText.trim();
+                }
+            }
+        }
+        return null;
+    }
+
     function extractAndShowData() {
         // 1. COMPANY
         const company = extractSingle('#vcomp .form-body', [
@@ -98,7 +115,14 @@
             {name: 'name', label: 'name'},
             {name: 'address', label: 'address'},
             {name: 'status', label: 'subscription'}
-        ]);
+        ]) || {};
+
+        // Detectar el estatus de suscripción del Registered Agent desde la
+        // pestaña de Subscriptions.
+        const agentSub = getAgentSubscriptionStatus();
+        if (agentSub) {
+            agent.status = agentSub;
+        }
 
         // 3. DIRECTORS/MEMBERS
         const directors = extractRows('#vmembers .form-body', [
@@ -137,7 +161,7 @@
             </div>`;
         }
         // AGENT
-        if (agent) {
+        if (agent && Object.values(agent).some(v => v)) {
             html += `
             <div class="white-box" style="margin-bottom:14px">
                 <div class="box-title">AGENT</div>


### PR DESCRIPTION
## Summary
- parse the Registered Agent subscription status from the DB page
- show the status in the sidebar Agent section

## Testing
- `node -e "require('./environments/db/db_launcher.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68492314ebb4832681139d4a4ef1e943