### PR TITLE
Improve DB address extraction

### DIFF
--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -85,13 +85,26 @@
 
     function extractAndShowData() {
         // 1. COMPANY
-        const company = extractSingle('#vcomp .form-body', [
+        const companyRaw = extractSingle('#vcomp .form-body', [
             {name: 'name', label: 'company name'},
             {name: 'originalName', label: 'original name'},
             {name: 'state', label: 'state of formation'},
             {name: 'purpose', label: 'purpose'},
+            {name: 'street', label: 'street'},
+            {name: 'street1', label: 'street 1'},
+            {name: 'cityStateZip', label: 'city, state, zip'},
             {name: 'address', label: 'address'}
         ]);
+        const company = companyRaw ? {
+            name: companyRaw.name,
+            originalName: companyRaw.originalName,
+            state: companyRaw.state,
+            purpose: companyRaw.purpose,
+            address: [
+                companyRaw.address || companyRaw.street || companyRaw.street1,
+                companyRaw.cityStateZip
+            ].filter(Boolean).join(', ')
+        } : null;
 
         // 2. AGENT
         const agent = extractSingle('#vagent .form-body', [
@@ -101,25 +114,58 @@
         ]);
 
         // 3. DIRECTORS/MEMBERS
-        const directors = extractRows('#vmembers .form-body', [
+        const directorsRaw = extractRows('#vmembers .form-body', [
             {name: 'name', label: 'name'},
             {name: 'address', label: 'address'},
+            {name: 'street', label: 'street'},
+            {name: 'street1', label: 'street 1'},
+            {name: 'cityStateZip', label: 'city, state, zip'},
             {name: 'position', label: 'position'}
         ]);
+        const directors = directorsRaw.map(d => ({
+            name: d.name,
+            address: [
+                d.address || d.street || d.street1,
+                d.cityStateZip
+            ].filter(Boolean).join(', '),
+            position: d.position
+        }));
 
         // 4. SHAREHOLDERS
-        const shareholders = extractRows('#vshareholders .form-body', [
+        const shareholdersRaw = extractRows('#vshareholders .form-body', [
             {name: 'name', label: 'name'},
             {name: 'address', label: 'address'},
+            {name: 'street', label: 'street'},
+            {name: 'street1', label: 'street 1'},
+            {name: 'cityStateZip', label: 'city, state, zip'},
             {name: 'shares', label: 'share'}
         ]);
+        const shareholders = shareholdersRaw.map(s => ({
+            name: s.name,
+            address: [
+                s.address || s.street || s.street1,
+                s.cityStateZip
+            ].filter(Boolean).join(', '),
+            shares: s.shares
+        }));
 
         // 5. OFFICERS
-        const officers = extractRows('#vofficers .form-body', [
+        const officersRaw = extractRows('#vofficers .form-body', [
             {name: 'name', label: 'name'},
             {name: 'address', label: 'address'},
+            {name: 'street', label: 'street'},
+            {name: 'street1', label: 'street 1'},
+            {name: 'cityStateZip', label: 'city, state, zip'},
             {name: 'position', label: 'position'}
         ]);
+        const officers = officersRaw.map(o => ({
+            name: o.name,
+            address: [
+                o.address || o.street || o.street1,
+                o.cityStateZip
+            ].filter(Boolean).join(', '),
+            position: o.position
+        }));
 
         // Render del HTML
         let html = '';


### PR DESCRIPTION
## Summary
- fetch company street fields when scraping DB pages
- build a single concatenated company address
- capture street details for directors, shareholders and officers

## Testing
- `node -e "const fs=require('fs'); new Function(fs.readFileSync('environments/db/db_launcher.js','utf8')); console.log('Syntax OK');"`

------
https://chatgpt.com/codex/tasks/task_e_6849232053188326ac4ce514e4c926cf