### PR TITLE
Add emojis to DB sidebar titles

### DIFF
--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -198,7 +198,7 @@
         if (company) {
             html += `
             <div class="white-box" style="margin-bottom:14px">
-                <div class="box-title">COMPANY</div>
+                <div class="box-title">🏢 COMPANY</div>
                 <div><strong>Name:</strong> ${company.name || '<span style="color:#aaa">-</span>'}</div>
                 <div><strong>Original Name:</strong> ${company.originalName || '<span style="color:#aaa">-</span>'}</div>
                 <div><strong>State:</strong> ${company.state || '<span style="color:#aaa">-</span>'}</div>
@@ -210,7 +210,7 @@
         if (agent && Object.values(agent).some(v => v)) {
             html += `
             <div class="white-box" style="margin-bottom:14px">
-                <div class="box-title">AGENT</div>
+                <div class="box-title">🕵️ AGENT</div>
                 <div><strong>Name:</strong> ${agent.name || '<span style="color:#aaa">-</span>'}</div>
                 <div><strong>Address:</strong> ${agent.address || '<span style="color:#aaa">-</span>'}</div>
                 <div><strong>Subscription:</strong> ${agent.status || '<span style="color:#aaa">-</span>'}</div>
@@ -220,7 +220,7 @@
         if (directors.length) {
             html += `
             <div class="white-box" style="margin-bottom:14px">
-                <div class="box-title">DIRECTORS</div>
+                <div class="box-title">👥 DIRECTORS</div>
                 ${directors.map(d => `
                     <div><strong>Name:</strong> ${d.name || '<span style="color:#aaa">-</span>'}</div>
                     <div><strong>Address:</strong> ${d.address || '<span style="color:#aaa">-</span>'}</div>
@@ -233,7 +233,7 @@
         if (shareholders.length) {
             html += `
             <div class="white-box" style="margin-bottom:14px">
-                <div class="box-title">SHAREHOLDERS</div>
+                <div class="box-title">💰 SHAREHOLDERS</div>
                 ${shareholders.map(s => `
                     <div><strong>Name:</strong> ${s.name || '<span style="color:#aaa">-</span>'}</div>
                     <div><strong>Address:</strong> ${s.address || '<span style="color:#aaa">-</span>'}</div>
@@ -246,7 +246,7 @@
         if (officers.length) {
             html += `
             <div class="white-box" style="margin-bottom:14px">
-                <div class="box-title">OFFICERS</div>
+                <div class="box-title">👮 OFFICERS</div>
                 ${officers.map(o => `
                     <div><strong>Name:</strong> ${o.name || '<span style="color:#aaa">-</span>'}</div>
                     <div><strong>Address:</strong> ${o.address || '<span style="color:#aaa">-</span>'}</div>


### PR DESCRIPTION
## Summary
- show relevant emojis for COMPANY, AGENT, DIRECTORS, SHAREHOLDERS, and OFFICERS in the database sidebar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684926e14f8083269bb1d8c89d58ca32