### PR TITLE
Adjust DB sidebar section background

### DIFF
--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -102,7 +102,7 @@
 
 /* Ensure DB sidebar sections remain readable */
 #copilot-sidebar .white-box {
-    background-color: #fff;
+    background-color: #f5f5f5;
     color: #000 !important;
     border-radius: 8px;
 }


### PR DESCRIPTION
## Summary
- tweak the `white-box` style to use a softer grey background in the DB sidebar

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684926fd0378832695fed77a5a5daf89