### PR TITLE
Improve address detection

### DIFF
--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -54,6 +54,23 @@
         return `<a href="#" class="copilot-address" data-address="${esc}">${esc}</a>`;
     }
 
+    function buildAddress(obj) {
+        if (!obj) return '';
+        const parts = [];
+        const line1 = obj.address || obj.street || obj.street1;
+        if (line1) parts.push(line1);
+        if (obj.street2) parts.push(obj.street2);
+        if (obj.cityStateZipCountry) {
+            parts.push(obj.cityStateZipCountry);
+        } else {
+            if (obj.cityStateZip) parts.push(obj.cityStateZip);
+            if (obj.country && (!obj.cityStateZip || !obj.cityStateZip.includes(obj.country))) {
+                parts.push(obj.country);
+            }
+        }
+        return parts.filter(Boolean).join(', ');
+    }
+
     // Scrapea los .row de una sección dada y devuelve array de objetos campo:valor
     function extractRows(sectionSel, fields) {
         const root = document.querySelector(sectionSel);
@@ -165,7 +182,10 @@
             {name: 'purpose', label: 'purpose'},
             {name: 'street', label: 'street'},
             {name: 'street1', label: 'street 1'},
+            {name: 'street2', label: 'street 2'},
+            {name: 'cityStateZipCountry', label: 'city, state, zip, country'},
             {name: 'cityStateZip', label: 'city, state, zip'},
+            {name: 'country', label: 'country'},
             {name: 'address', label: 'address'}
         ]);
 
@@ -176,18 +196,26 @@
             state: companyRaw.state,
             status: companyRaw.status || headerStatus,
             purpose: companyRaw.purpose,
-            address: [
-                companyRaw.address || companyRaw.street || companyRaw.street1,
-                companyRaw.cityStateZip
-            ].filter(Boolean).join(', ')
+            address: buildAddress(companyRaw)
         } : (headerStatus ? { status: headerStatus } : null);
 
         // 2. AGENT
-        const agent = extractSingle('#vagent .form-body', [
+        const agentRaw = extractSingle('#vagent .form-body', [
             {name: 'name', label: 'name'},
             {name: 'address', label: 'address'},
+            {name: 'street', label: 'street'},
+            {name: 'street1', label: 'street 1'},
+            {name: 'street2', label: 'street 2'},
+            {name: 'cityStateZipCountry', label: 'city, state, zip, country'},
+            {name: 'cityStateZip', label: 'city, state, zip'},
+            {name: 'country', label: 'country'},
             {name: 'status', label: 'subscription'}
-        ]) || {};
+        ]);
+        const agent = agentRaw ? {
+            name: agentRaw.name,
+            status: agentRaw.status,
+            address: buildAddress(agentRaw)
+        } : {};
 
         // Detectar el estatus de suscripción del Registered Agent desde la
         // pestaña de Subscriptions.
@@ -207,15 +235,15 @@
             {name: 'address', label: 'address'},
             {name: 'street', label: 'street'},
             {name: 'street1', label: 'street 1'},
+            {name: 'street2', label: 'street 2'},
+            {name: 'cityStateZipCountry', label: 'city, state, zip, country'},
             {name: 'cityStateZip', label: 'city, state, zip'},
+            {name: 'country', label: 'country'},
             {name: 'position', label: 'position'}
         ]);
         const directors = directorsRaw.map(d => ({
             name: d.name,
-            address: [
-                d.address || d.street || d.street1,
-                d.cityStateZip
-            ].filter(Boolean).join(', '),
+            address: buildAddress(d),
             position: d.position
         }));
 
@@ -225,15 +253,15 @@
             {name: 'address', label: 'address'},
             {name: 'street', label: 'street'},
             {name: 'street1', label: 'street 1'},
+            {name: 'street2', label: 'street 2'},
+            {name: 'cityStateZipCountry', label: 'city, state, zip, country'},
             {name: 'cityStateZip', label: 'city, state, zip'},
+            {name: 'country', label: 'country'},
             {name: 'shares', label: 'share'}
         ]);
         const shareholders = shareholdersRaw.map(s => ({
             name: s.name,
-            address: [
-                s.address || s.street || s.street1,
-                s.cityStateZip
-            ].filter(Boolean).join(', '),
+            address: buildAddress(s),
             shares: s.shares
         }));
 
@@ -243,15 +271,15 @@
             {name: 'address', label: 'address'},
             {name: 'street', label: 'street'},
             {name: 'street1', label: 'street 1'},
+            {name: 'street2', label: 'street 2'},
+            {name: 'cityStateZipCountry', label: 'city, state, zip, country'},
             {name: 'cityStateZip', label: 'city, state, zip'},
+            {name: 'country', label: 'country'},
             {name: 'position', label: 'position'}
         ]);
         const officers = officersRaw.map(o => ({
             name: o.name,
-            address: [
-                o.address || o.street || o.street1,
-                o.cityStateZip
-            ].filter(Boolean).join(', '),
+            address: buildAddress(o),
             position: o.position
         }));
 


### PR DESCRIPTION
## Summary
- include street2 and country fields when scraping
- add `buildAddress` helper for normalized address strings across company, agent, members, shareholders and officers

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68492d3f4e108326b1c26d12db88fd8f