### PR TITLE
Fix sticky sidebar reopening

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ information scraped from the current page.
 - Extracts order number, sender email and name from the open email.
 - Displays a small order summary inside the sidebar.
 - Opens Gmail search and the DB order page in new tabs when clicking the buttons.
+ - If you close the sidebar it will remain hidden until the tab is reloaded.
 
 ### DB
 - Displays a sidebar on order detail pages.

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1,6 +1,7 @@
 (function main() {
     try {
         function initSidebar() {
+            if (sessionStorage.getItem('copilotSidebarClosed') === 'true') return;
             if (!document.getElementById('copilot-sidebar')) {
                 console.log("[Copilot] Sidebar no encontrado, inyectando en DB...");
 
@@ -26,6 +27,7 @@
                     document.getElementById('copilot-close').onclick = () => {
                         sidebar.remove();
                         document.body.style.marginRight = '';
+                        sessionStorage.setItem('copilotSidebarClosed', 'true');
                         console.log("[Copilot] Sidebar cerrado manualmente en DB.");
                     };
                     extractAndShowData();

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -134,6 +134,7 @@
             document.getElementById('copilot-close').onclick = () => {
                 sidebar.remove();
                 mainPanels.forEach(el => el.style.paddingRight = '');
+                sessionStorage.setItem('copilotSidebarClosed', 'true');
                 console.log("[Copilot] Sidebar cerrado manualmente en Gmail.");
             };
 
@@ -142,6 +143,7 @@
         }
 
         function injectSidebarIfMissing() {
+            if (sessionStorage.getItem('copilotSidebarClosed') === 'true') return;
             if (!document.getElementById('copilot-sidebar')) {
                 console.log("[Copilot] Sidebar no encontrado, inyectando en Gmail...");
                 const mainPanels = applyPaddingToMainPanels();


### PR DESCRIPTION
## Summary
- keep Gmail sidebar closed when manually dismissed
- keep DB sidebar closed when manually dismissed
- document new behaviour in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684996a8f65083268e1b55590dcb1d77