### PR TITLE
Fix Gmail sidebar spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ information scraped from the current page.
 - Extracts order number, sender email and name from the open email.
 - Displays a small order summary inside the sidebar.
 - Opens Gmail search and the DB order page in new tabs when clicking the buttons.
+- Uses `margin-right` to ensure Gmail navigation controls stay visible.
  - If you close the sidebar it will remain hidden until the tab is reloaded.
 
 ### DB

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -20,8 +20,10 @@
             }
 
             mainPanels.forEach((el, i) => {
-                el.style.setProperty("padding-right", SIDEBAR_WIDTH + "px", "important");
-                el.style.setProperty("transition", "padding-right 0.2s", "important");
+                // Usamos margin-right para no desplazar
+                // elementos de paginación fuera de la vista
+                el.style.setProperty("margin-right", SIDEBAR_WIDTH + "px", "important");
+                el.style.setProperty("transition", "margin-right 0.2s", "important");
             });
 
             return mainPanels;
@@ -133,7 +135,8 @@
             // Botón de cierre
             document.getElementById('copilot-close').onclick = () => {
                 sidebar.remove();
-                mainPanels.forEach(el => el.style.paddingRight = '');
+                // Limpiar el margin aplicado a los paneles
+                mainPanels.forEach(el => el.style.marginRight = '');
                 sessionStorage.setItem('copilotSidebarClosed', 'true');
                 console.log("[Copilot] Sidebar cerrado manualmente en Gmail.");
             };


### PR DESCRIPTION
## Summary
- prevent Gmail page nav from being hidden by switching sidebar padding to margin
- document new behavior in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684996dcf73083268296e40794fac4d5