### PR TITLE
Improve Gmail search when order missing

### DIFF
--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -90,12 +90,11 @@
             const context = extractOrderContextFromEmail();
             fillOrderSummaryBox(context);
 
-            if (!context || !context.orderNumber || !context.email) {
-                alert("No se pudo detectar orden y email del cliente.");
+            if (!context || !context.email) {
+                alert("No se pudo detectar el correo del cliente.");
                 return;
             }
 
-            // Generar búsqueda con OR
             const queryParts = [];
             if (context.orderNumber) queryParts.push(context.orderNumber);
             if (context.email) queryParts.push(`"${context.email}"`);
@@ -103,9 +102,19 @@
 
             const finalQuery = queryParts.join(" OR ");
             const gmailSearchUrl = `https://mail.google.com/mail/u/0/#search/${encodeURIComponent(finalQuery)}`;
-            const dbOrderUrl = `https://db.incfile.com/incfile/order/detail/${context.orderNumber}`;
 
-            chrome.runtime.sendMessage({ action: "openTabs", urls: [gmailSearchUrl, dbOrderUrl] });
+            const urls = [gmailSearchUrl];
+
+            if (context.orderNumber) {
+                const dbOrderUrl = `https://db.incfile.com/incfile/order/detail/${context.orderNumber}`;
+                urls.push(dbOrderUrl);
+            } else {
+                const dbSearchUrl = "https://db.incfile.com/order-tracker/orders/order-search";
+                urls.push(dbSearchUrl);
+                navigator.clipboard.writeText(context.email).catch(err => console.error("[FENNEC] Clipboard error:", err));
+            }
+
+            chrome.runtime.sendMessage({ action: "openTabs", urls });
         }
 
         function injectSidebar(mainPanels) {


### PR DESCRIPTION
## Summary
- change Gmail email search behavior
  - if there's an order number, open Gmail search and DB order detail
  - if the order number isn't detected, search Gmail by name/email and open the DB order-search page, copying the email to the clipboard

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849a678f4688326a91e9fe80aa90f20