### PR TITLE
Fix OFFICERS summary display

### DIFF
--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -408,10 +408,10 @@
         if (officers.length) {
             html += `
             <div class="white-box" style="margin-bottom:10px">
-                <div class="box-title">👮 OFFICERS</div>
+                <div class="box-title">👮</div>
                 ${officers.map(o => `
                     <div><b>${renderCopy(o.name)}</b></div>
-                    <div>${renderAddress(o.address)}</div>
+                    ${o.address ? `<div>${renderAddress(o.address)}</div>` : ''}
                     <div>${renderCopy(o.position)}</div>
                 `).join('<hr style="border:none; border-top:1px solid #eee; margin:6px 0"/>')}
             </div>`;

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -118,7 +118,7 @@
 
 /* Ensure DB sidebar sections remain readable */
 #copilot-sidebar .white-box {
-    background-color: #f5f5f5;
+    background-color: #dcdcdc;
     color: #000 !important;
     border-radius: 8px;
     font-size: 12px;


### PR DESCRIPTION
## Summary
- show only the icon for OFFICERS summary and skip empty addresses
- darken white-box background color by 10%

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849bdb357208326a42a5074ce4d43c5