### PR TITLE
Add toggle to enable or disable extension

### DIFF
--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1,5 +1,10 @@
 (function main() {
-    try {
+    chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
+        if (!extensionEnabled) {
+            console.log('[FENNEC] Extension disabled, skipping DB launcher.');
+            return;
+        }
+        try {
         function initSidebar() {
             if (sessionStorage.getItem('copilotSidebarClosed') === 'true') return;
             if (!document.getElementById('copilot-sidebar')) {
@@ -451,4 +456,5 @@
             });
         }
     }
+    });
 })();

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1,6 +1,11 @@
 (function persistentSidebar() {
-    try {
-        const SIDEBAR_WIDTH = 340;
+    chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
+        if (!extensionEnabled) {
+            console.log('[FENNEC] Extension disabled, skipping Gmail launcher.');
+            return;
+        }
+        try {
+            const SIDEBAR_WIDTH = 340;
 
         function applyPaddingToMainPanels() {
             const candidates = [
@@ -229,4 +234,5 @@
     } catch (e) {
         console.error("[Copilot] ERROR en Gmail Launcher:", e);
     }
+    });
 })();

--- a/environments/usps/usps_launcher.js
+++ b/environments/usps/usps_launcher.js
@@ -1,5 +1,10 @@
 (function() {
-    try {
+    chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
+        if (!extensionEnabled) {
+            console.log('[FENNEC] Extension disabled, skipping USPS launcher.');
+            return;
+        }
+        try {
         const params = new URLSearchParams(window.location.search);
         const addr = params.get('fennec_addr');
         if (!addr) return;
@@ -87,4 +92,5 @@
     } catch (e) {
         console.error('[FENNEC USPS] Launcher error:', e);
     }
+    });
 })();

--- a/manifest.json
+++ b/manifest.json
@@ -61,6 +61,14 @@
     "48": "icons/copilot_icon.png",
     "128": "icons/copilot_icon.png"
   },
+  "action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "icons/copilot_icon.png",
+      "48": "icons/copilot_icon.png",
+      "128": "icons/copilot_icon.png"
+    }
+  },
   "background": {
     "service_worker": "core/background_emailsearch.js",
     "type": "module"

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <style>
+    body { font-family: Arial, sans-serif; min-width: 180px; padding: 10px; }
+    #toggle-wrapper { display: flex; align-items: center; }
+    #extension-toggle { margin-right: 8px; }
+  </style>
+</head>
+<body>
+  <div id="toggle-wrapper">
+    <input type="checkbox" id="extension-toggle">
+    <label for="extension-toggle">Enable FENNEC</label>
+  </div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,17 @@
+// Handles enable/disable toggle
+const toggle = document.getElementById('extension-toggle');
+
+function loadState() {
+  chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
+    toggle.checked = Boolean(extensionEnabled);
+  });
+}
+
+function saveState() {
+  chrome.storage.local.set({ extensionEnabled: toggle.checked });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadState();
+  toggle.addEventListener('change', saveState);
+});


### PR DESCRIPTION
## Summary
- add popup for enabling/disabling extension
- update manifest to show popup when clicking the extension icon
- stop injecting content scripts when extension is disabled

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6849c2f3b5148326811d24cdc7241de0