### PR TITLE
Handle toggle by updating open pages

### DIFF
--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1,4 +1,9 @@
 (function main() {
+    chrome.runtime.onMessage.addListener((msg) => {
+        if (msg.action === 'fennecToggle') {
+            window.location.reload();
+        }
+    });
     chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
         if (!extensionEnabled) {
             console.log('[FENNEC] Extension disabled, skipping DB launcher.');

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1,4 +1,9 @@
 (function persistentSidebar() {
+    chrome.runtime.onMessage.addListener((msg) => {
+        if (msg.action === 'fennecToggle') {
+            window.location.reload();
+        }
+    });
     chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
         if (!extensionEnabled) {
             console.log('[FENNEC] Extension disabled, skipping Gmail launcher.');

--- a/environments/usps/usps_launcher.js
+++ b/environments/usps/usps_launcher.js
@@ -1,4 +1,9 @@
 (function() {
+    chrome.runtime.onMessage.addListener((msg) => {
+        if (msg.action === 'fennecToggle') {
+            window.location.reload();
+        }
+    });
     chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
         if (!extensionEnabled) {
             console.log('[FENNEC] Extension disabled, skipping USPS launcher.');

--- a/popup.js
+++ b/popup.js
@@ -8,7 +8,27 @@ function loadState() {
 }
 
 function saveState() {
-  chrome.storage.local.set({ extensionEnabled: toggle.checked });
+  chrome.storage.local.set({ extensionEnabled: toggle.checked }, () => {
+    const urls = [
+      'https://mail.google.com/*',
+      'https://db.incfile.com/incfile/order/detail/*',
+      'https://tools.usps.com/*'
+    ];
+
+    chrome.tabs.query({ url: urls }, tabs => {
+      tabs.forEach(tab => {
+        chrome.tabs.sendMessage(
+          tab.id,
+          { action: 'fennecToggle', enabled: toggle.checked },
+          () => {
+            if (chrome.runtime.lastError) {
+              chrome.tabs.reload(tab.id);
+            }
+          }
+        );
+      });
+    });
+  });
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- notify open tabs when the extension toggle changes
- content scripts reload themselves when notified so sidebars match the toggle state

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849c57dea508326ac36950713e0bcb9