### PR TITLE
Add subject filter to Gmail search

### DIFF
--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -107,7 +107,10 @@
             }
 
             const queryParts = [];
-            if (context.orderNumber) queryParts.push(context.orderNumber);
+            if (context.orderNumber) {
+                queryParts.push(context.orderNumber);
+                queryParts.push(`subject:"${context.orderNumber}"`);
+            }
             if (context.email) queryParts.push(`"${context.email}"`);
             if (context.name) queryParts.push(`"${context.name}"`);
 


### PR DESCRIPTION
## Summary
- broaden Gmail search to match the order number in the subject

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849dafcd2248326a23a98f426fde9ab