### PR TITLE
Use FENNEC icon and update extension name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FENNEC
+# FENNEC (Prototype)
 
 FENNEC is a small Chrome extension that injects a "copilot" style sidebar into
 Gmail and the internal DB interface. It helps open related tabs and shows order

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -36,8 +36,8 @@
                     sidebar.id = 'copilot-sidebar';
                     sidebar.innerHTML = `
                         <div class="copilot-header">
-                            <img src="${chrome.runtime.getURL('icons/copilot_icon.png')}" class="copilot-icon" alt="FENNEC" />
-                            <span>FENNEC</span>
+                            <img src="${chrome.runtime.getURL('FENNEC ICON.png')}" class="copilot-icon" alt="FENNEC (Prototype)" />
+                            <span>FENNEC (Prototype)</span>
                             <button id="copilot-close">✕</button>
                         </div>
                         <div class="copilot-body" id="copilot-body-content">

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -138,8 +138,8 @@
             sidebar.id = 'copilot-sidebar';
             sidebar.innerHTML = `
                 <div class="copilot-header">
-                    <img src="${chrome.runtime.getURL('icons/copilot_icon.png')}" class="copilot-icon" alt="Copilot" />
-                    <span>FENNEC</span>
+                    <img src="${chrome.runtime.getURL('FENNEC ICON.png')}" class="copilot-icon" alt="FENNEC (Prototype)" />
+                    <span>FENNEC (Prototype)</span>
                     <button id="copilot-close">✕</button>
                 </div>
                 <div class="copilot-body">

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "Copilot Sidebar",
+  "name": "FENNEC (Prototype)",
   "description": "Barra lateral tipo copilot para Gmail y DB",
   "version": "1.0.3",
   "permissions": [
@@ -49,7 +49,7 @@
   "web_accessible_resources": [
     {
       "resources": [
-        "icons/copilot_icon.png"
+        "FENNEC ICON.png"
       ],
       "matches": [
         "<all_urls>"
@@ -57,16 +57,16 @@
     }
   ],
   "icons": {
-    "16": "icons/copilot_icon.png",
-    "48": "icons/copilot_icon.png",
-    "128": "icons/copilot_icon.png"
+    "16": "FENNEC ICON.png",
+    "48": "FENNEC ICON.png",
+    "128": "FENNEC ICON.png"
   },
   "action": {
     "default_popup": "popup.html",
     "default_icon": {
-      "16": "icons/copilot_icon.png",
-      "48": "icons/copilot_icon.png",
-      "128": "icons/copilot_icon.png"
+      "16": "FENNEC ICON.png",
+      "48": "FENNEC ICON.png",
+      "128": "FENNEC ICON.png"
     }
   },
   "background": {


### PR DESCRIPTION
## Summary
- rename the extension to **FENNEC (Prototype)**
- point the manifest and UI to `FENNEC ICON.png`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849e8e509dc8326a00af356ac16a197