### PR TITLE
Update sidebar headers style

### DIFF
--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -36,8 +36,10 @@
                     sidebar.id = 'copilot-sidebar';
                     sidebar.innerHTML = `
                         <div class="copilot-header">
-                            <img src="${chrome.runtime.getURL('fennec_icon.png')}" class="copilot-icon" alt="FENNEC (Prototype)" />
-                            <span>FENNEC (Prototype)</span>
+                            <div class="copilot-title">
+                                <img src="${chrome.runtime.getURL('fennec_icon.png')}" class="copilot-icon" alt="FENNEC (Prototype)" />
+                                <span>FENNEC (Prototype)</span>
+                            </div>
                             <button id="copilot-close">✕</button>
                         </div>
                         <div class="copilot-body" id="copilot-body-content">

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -138,8 +138,10 @@
             sidebar.id = 'copilot-sidebar';
             sidebar.innerHTML = `
                 <div class="copilot-header">
-                    <img src="${chrome.runtime.getURL('fennec_icon.png')}" class="copilot-icon" alt="FENNEC (Prototype)" />
-                    <span>FENNEC (Prototype)</span>
+                    <div class="copilot-title">
+                        <img src="${chrome.runtime.getURL('fennec_icon.png')}" class="copilot-icon" alt="FENNEC (Prototype)" />
+                        <span>FENNEC (Prototype)</span>
+                    </div>
                     <button id="copilot-close">✕</button>
                 </div>
                 <div class="copilot-body">

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -15,19 +15,27 @@
 .copilot-header {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     padding: 12px;
-    background: #111;
+    background: #c6c6c6;
+    color: #000;
     border-bottom: 1px solid #444;
 }
 .copilot-icon {
     width: 28px; height: 28px; margin-right: 10px;
 }
-.copilot-header span {
+.copilot-title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     flex: 1;
+}
+.copilot-header span {
     font-weight: bold;
+    margin-left: 8px;
 }
 #copilot-close {
-    background: none; border: none; color: #fff; font-size: 20px;
+    background: none; border: none; color: #000; font-size: 20px;
     cursor: pointer; outline: none;
 }
 .copilot-body {


### PR DESCRIPTION
## Summary
- center titles in both sidebars
- match sidebar header color with DB summary boxes

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6849ed3a1abc8326be8726c23e836b3f