### PR TITLE
Add Potential Intel box with clickable intel

### DIFF
--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -124,6 +124,17 @@
     text-align: center;
 }
 
+.intel-summary-box {
+    background-color: #2e2e2e;
+    color: #f1f1f1;
+    padding: 8px;
+    margin-top: 12px;
+    border-radius: 8px;
+    font-size: 13px;
+    line-height: 1.4em;
+    text-align: center;
+}
+
 /* Ensure DB sidebar sections remain readable */
 #copilot-sidebar .white-box {
     /* Slightly darker background for readability */


### PR DESCRIPTION
## Summary
- add `intel-summary-box` styling
- show potential names and addresses in a new "POTENTIAL INTEL" panel
- make order summary and intel data interactive with copy, Google search and USPS actions

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b006e8e108326a724bd41d0972b6c