### PR TITLE
Update RA/VA status detection

### DIFF
--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -586,8 +586,28 @@
 
         const orderItems = Array.from(document.querySelectorAll('.order-items li'))
             .map(li => li.innerText.trim().toLowerCase());
-        const hasRA = orderItems.some(t => t.includes('registered agent'));
-        const hasVA = orderItems.some(t => t.includes('virtual address'));
+
+        // Registered Agent subscription status from #vagent section
+        const hasRA = /^yes/i.test(agent.status || '');
+
+        // Virtual Address status from #vvirtual-address section or fallback button
+        let hasVA = false;
+        const vaSection = document.querySelector('#vvirtual-address');
+        if (vaSection) {
+            const vaTexts = Array.from(vaSection.querySelectorAll('td, span'))
+                .map(el => el.innerText.trim().toLowerCase());
+            hasVA = vaTexts.some(t => t.includes('active'));
+            if (!hasVA && vaTexts.some(t => t.includes('inactive'))) {
+                hasVA = false;
+            }
+        } else {
+            const vaBtn = Array.from(document.querySelectorAll('button'))
+                .find(b => /virtual address/i.test(b.innerText));
+            if (vaBtn) {
+                const txt = vaBtn.innerText.toLowerCase();
+                hasVA = txt.includes('active');
+            }
+        }
         const isVAAddress = addr => hasVA && /#\s*\d{3,}/.test(addr);
 
         const addrEntries = Object.values(addrMap)


### PR DESCRIPTION
## Summary
- derive RA subscription state from the `#vagent` section
- derive Virtual Address state from `#vvirtual-address` or its status button

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684b258e42708326a083e4112c281ba0