### PR TITLE
Fix agent No Service tag

### DIFF
--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -653,18 +653,14 @@
             const expired = expDate && expDate < new Date();
             let status = (agent.status || '').trim();
             let statusClass = 'copilot-tag';
+            let statusDisplay = '';
             if (/^yes/i.test(status)) {
                 statusClass += ' copilot-tag-green';
-            } else if (/no service/i.test(status)) {
-                statusClass += ' copilot-tag-white';
+                statusDisplay = `Active${agent.expiration ? ` (${escapeHtml(agent.expiration)})` : ''}`;
             } else if (/resigned|staged for resignatio/i.test(status) || expired) {
                 statusClass += ' copilot-tag-red';
-            }
-
-            let statusDisplay = '';
-            if (/no service/i.test(status)) {
-                statusDisplay = 'No Service';
-            } else if (status) {
+                statusDisplay = `Resigned${agent.expiration ? ` (${escapeHtml(agent.expiration)})` : ''}`;
+            } else if (status && !/no service/i.test(status)) {
                 statusDisplay = `${status}${agent.expiration ? ` (${escapeHtml(agent.expiration)})` : ''}`;
             }
             const statusHtml = statusDisplay ? `<span class="${statusClass}">${escapeHtml(statusDisplay)}</span>`


### PR DESCRIPTION
## Summary
- adjust DB sidebar agent status logic so `No Service` shows no tag
- display Active or Resigned with expiration date

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b25eea2248326b9e38c8d2c9a0acc