### PR TITLE
Fix quick summary label text color

### DIFF
--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -238,7 +238,7 @@
 }
 .copilot-tag-white {
     background-color: #fff;
-    color: #333;
+    color: #333 !important;
     border: 1px solid #ccc;
 }
 .copilot-tag-red {


### PR DESCRIPTION
## Summary
- ensure `.copilot-tag-white` text color isn't overridden

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b289e4bfc83269ba93a70a22bc0c1