### PR TITLE
Adjust quick summary styles

### DIFF
--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -629,7 +629,7 @@
             summaryParts.push(...roleEntries);
         }
         if (addrEntries.length) {
-            if (summaryParts.length) summaryParts.push('<div style="height:4px"></div>');
+            if (summaryParts.length) summaryParts.push('<hr style="border:none;border-top:1px solid #eee;margin:6px 0"/>');
             summaryParts.push(...addrEntries);
         }
         summaryParts.push('<div style="height:4px"></div>');

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -205,8 +205,8 @@
 }
 
 #copilot-sidebar .white-box.quick-summary-content {
-    font-size: 12px;
-    line-height: 1.6em;
+    font-size: 13px;
+    line-height: 1.4em;
 }
 
 #copilot-sidebar #quick-summary.quick-summary-collapsed {


### PR DESCRIPTION
## Summary
- tweak font-size for quick summary section
- insert a separator line between role and address lists in DB sidebar

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684b28e438c08326a9db64c5cc44e305