### PR TITLE
Fix tag text color for DB sidebar

### DIFF
--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -238,7 +238,7 @@
 }
 .copilot-tag-white {
     background-color: #fff;
-    color: #111 !important;
+    color: #000 !important;
     border: 1px solid #ccc;
 }
 .copilot-tag-red {


### PR DESCRIPTION
## Summary
- ensure tags with white background display black text

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b2b76593083269436ddbdb35e4fc3