### PR TITLE
Update subscription status label color

### DIFF
--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -642,8 +642,8 @@
             summaryParts.push(...addrEntries);
         }
         summaryParts.push('<div style="height:4px"></div>');
-        const raClass = hasRA ? 'copilot-tag copilot-tag-green' : 'copilot-tag copilot-tag-white';
-        const vaClass = hasVA ? 'copilot-tag copilot-tag-green' : 'copilot-tag copilot-tag-white';
+        const raClass = hasRA ? 'copilot-tag copilot-tag-green' : 'copilot-tag copilot-tag-purple';
+        const vaClass = hasVA ? 'copilot-tag copilot-tag-green' : 'copilot-tag copilot-tag-purple';
         summaryParts.push(`
             <br/>
             <div>

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -242,6 +242,10 @@
     opacity: 1;
     border: 1px solid #ccc;
 }
+.copilot-tag-purple {
+    background-color: #800080;
+    color: #fff;
+}
 .copilot-tag-red {
     background-color: #8B0000;
     color: #fff;


### PR DESCRIPTION
## Summary
- switch order summary subscription labels to use purple when inactive
- add purple tag style to sidebar CSS

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b2dba0a6883268ea9198ce39c9d1a