### PR TITLE
Add manual npm test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ information scraped from the current page.
 
 ## Development
 
-This repository now includes a minimal `package.json` to simplify future testing and build automation. It currently provides a placeholder test script:
+This repository now includes a minimal `package.json` to simplify future testing and build automation. The `npm test` command prints manual testing steps:
 
 ```bash
 npm test
 ```
 
-This will output `No tests configured` until automated tests are added.
+This will display instructions for manually verifying the extension inside Chrome.

--- a/manual-test.js
+++ b/manual-test.js
@@ -1,0 +1,8 @@
+// Prints manual testing steps for FENNEC Chrome extension
+console.log("Manual testing steps for FENNEC Chrome extension:");
+console.log("1. Open chrome://extensions in Chrome.");
+console.log("2. Enable Developer mode and click 'Load unpacked'.");
+console.log("3. Select this project folder.");
+console.log("4. Visit Gmail or the DB order detail pages to check the sidebar.");
+console.log("5. Verify the sidebar is absent on other sites.");
+console.log("6. Open the browser console and confirm there are no errors.");

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Prototype Chrome extension for Gmail and DB interface",
   "scripts": {
-    "test": "echo \"No tests configured\" && exit 1"
+    "test": "node manual-test.js"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- add a small script that prints manual test steps
- update the npm `test` script to run it
- document the new behavior in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c51bfe3008326a0b20f882bccd745