### PR TITLE
Display last issue in sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ information scraped from the current page.
 - Uses `margin-right` to ensure Gmail navigation controls stay visible.
 - The top header bar shifts left along with the main panels so account menus remain accessible.
 - If you close the sidebar it will remain hidden until the tab is reloaded.
-- When opening an order, the sidebar now retries for up to 10 seconds to display any
-  **ACTIVE ISSUE** found on the DB page. The script now also
-  checks the hidden table inside the `#modalUpdateIssue` modal
-  to support newer DB layouts.
+- When opening an order, the sidebar shows the **latest issue** from the DB page.
+  A label indicates whether it is **active** (red) or **resolved** (green). If no
+  issue is found, the box still appears with a link to the order. The script
+  checks the hidden table inside the `#modalUpdateIssue` modal to support newer
+  DB layouts.
 
 ### DB
 - Displays a sidebar on order detail pages.

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -137,6 +137,17 @@
     text-align: center;
 }
 
+.issue-summary-box {
+    background-color: #2e2e2e;
+    color: #f1f1f1;
+    padding: 8px;
+    margin-top: 12px;
+    border-radius: 8px;
+    font-size: 13px;
+    line-height: 1.4em;
+    text-align: center;
+}
+
 /* Ensure DB sidebar sections remain readable */
 #copilot-sidebar .white-box {
     background-color: #2e2e2e;
@@ -249,4 +260,20 @@
 .copilot-tag-red {
     background-color: #8B0000;
     color: #fff;
+}
+
+.issue-status-label {
+    font-size: 11px;
+    margin-left: 6px;
+    padding: 2px 6px;
+    border-radius: 4px;
+    color: #fff;
+}
+
+.issue-status-active {
+    background-color: #8B0000;
+}
+
+.issue-status-resolved {
+    background-color: #2ecc71;
 }


### PR DESCRIPTION
## Summary
- pull latest issue information from DB pages
- show issue status on Gmail sidebar and keep the box visible
- reorder sidebar boxes
- style issue status label
- document new behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c56cf26e88326b60fb00a73adcfc1