### PR TITLE
Improve issue fetch reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ information scraped from the current page.
   checks the hidden table inside the `#modalUpdateIssue` modal to support newer
   DB layouts. The issue lookup now tolerates trailing URL fragments so the link
   is shown even if the query fails. The parser now reads the issue timeline
-  description so only the message text appears in Gmail.
+  description so only the message text appears in Gmail. The sidebar now waits
+  a few seconds for the DB tab to finish loading before showing the issue,
+  improving reliability on slow connections.
 
 ### DB
 - Displays a sidebar on order detail pages.

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -4,13 +4,23 @@
             window.location.reload();
         }
         if (msg.action === 'getLastIssue') {
-            try {
-                const info = getLastIssueInfo();
-                sendResponse({ issueInfo: info });
-            } catch (err) {
-                console.warn('[FENNEC] Error extracting issue text:', err);
-                sendResponse({ issueInfo: null });
-            }
+            let attempts = 10;
+            const tryExtract = () => {
+                try {
+                    const info = getLastIssueInfo();
+                    if (info || attempts <= 0) {
+                        sendResponse({ issueInfo: info });
+                    } else {
+                        attempts--;
+                        setTimeout(tryExtract, 500);
+                    }
+                } catch (err) {
+                    console.warn('[FENNEC] Error extracting issue text:', err);
+                    sendResponse({ issueInfo: null });
+                }
+            };
+            tryExtract();
+            return true;
         }
     });
     chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {


### PR DESCRIPTION
## Summary
- retry issue extraction on the DB page before responding
- mention the retry behaviour in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c63a28ba0832689ade1d398ebc28a