### PR TITLE
Fix issue extraction from DB pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ information scraped from the current page.
   description so only the message text appears in Gmail. The sidebar now waits
   a few seconds for the DB tab to finish loading before showing the issue,
   improving reliability on slow connections.
+  Header rows in the hidden table are now skipped so issue details appear
+  even when the modal hasn't been opened.
 
 ### DB
 - Displays a sidebar on order detail pages.

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -812,13 +812,15 @@
             return { text, active };
         }
 
-        const modalRows = Array.from(document.querySelectorAll('#modalUpdateIssue table tbody tr'));
+        const modalRows = Array.from(document.querySelectorAll('#modalUpdateIssue table tbody tr'))
+            .filter(r => r.querySelectorAll('td').length >= 5);
         if (modalRows.length) {
             const info = parseRow(modalRows[0]);
             if (info) return info;
         }
 
-        const tableRows = Array.from(document.querySelectorAll('.issue-history table tbody tr'));
+        const tableRows = Array.from(document.querySelectorAll('.issue-history table tbody tr'))
+            .filter(r => r.querySelectorAll('td').length >= 5);
         if (tableRows.length) {
             const info = parseRow(tableRows[0]);
             if (info) return info;


### PR DESCRIPTION
## Summary
- improve DB issue parsing to ignore header rows
- document issue parsing tweak in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c653f7a9c8326b19e3cde69e540ae