### PR TITLE
Improve issue lookup retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ information scraped from the current page.
   until the DB tab reports it has finished loading before requesting the issue,
   improving reliability on slow connections.
   Header rows in the hidden table are now skipped so issue details appear
-  even when the modal hasn't been opened.
+  even when the modal hasn't been opened. Issue detection now retries longer
+  using exponential backoff and logs a warning if it ultimately times out.
 
 ### DB
 - Displays a sidebar on order detail pages.

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -456,7 +456,7 @@
             }
         }
 
-        function checkLastIssue(orderId, attempts = 10) {
+        function checkLastIssue(orderId, attempts = 15, delay = 1000) {
             if (!orderId) return;
             // Show placeholder immediately while we try to fetch the issue
             fillIssueBox(null, orderId);
@@ -465,17 +465,23 @@
             const tryFetch = () => {
                 chrome.tabs.query(query, tabs => {
                     const tab = tabs && tabs[0];
-                    if (!tab) {
-                        if (attempts > 0) setTimeout(() => { attempts--; tryFetch(); }, 1000);
+                    if (!tab || tab.status !== "complete") {
+                        if (attempts > 0) {
+                            setTimeout(() => { attempts--; delay = Math.min(delay * 1.5, 10000); tryFetch(); }, delay);
+                        } else {
+                            console.warn(`[Copilot] Issue check timed out for order ${orderId}`);
+                            fillIssueBox(null, orderId);
+                        }
                         return;
                     }
-                    if (tab.status !== 'complete') {
-                        if (attempts > 0) setTimeout(() => { attempts--; tryFetch(); }, 1000);
-                        return;
-                    }
-                    chrome.tabs.sendMessage(tab.id, { action: 'getLastIssue' }, resp => {
+                    chrome.tabs.sendMessage(tab.id, { action: "getLastIssue" }, resp => {
                         if (chrome.runtime.lastError) {
-                            if (attempts > 0) setTimeout(() => { attempts--; tryFetch(); }, 1000);
+                            if (attempts > 0) {
+                                setTimeout(() => { attempts--; delay = Math.min(delay * 1.5, 10000); tryFetch(); }, delay);
+                            } else {
+                                console.warn(`[Copilot] Issue check timed out for order ${orderId}`);
+                                fillIssueBox(null, orderId);
+                            }
                             return;
                         }
                         fillIssueBox(resp && resp.issueInfo, orderId);


### PR DESCRIPTION
## Summary
- extend `checkLastIssue` retries using exponential backoff
- warn when the maximum retries are exceeded
- document the longer retry behavior in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c6b8a649883268f97521a395221a3