### PR TITLE
Hide RA status line for external agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ information scraped from the current page.
 - Displays a sidebar on order detail pages.
 - Scrapes company, agent and officer data and presents it in a compact layout.
 - Addresses are clickable to open a Google search and copy the text.
+- Hides the agent subscription status line when RA service is not provided by Incfile.
 
 ## Known limitations
 

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -699,17 +699,18 @@
         if (agent && Object.values(agent).some(v => v)) {
             const expDate = agent.expiration ? parseDate(agent.expiration) : null;
             const expired = expDate && expDate < new Date();
-            let status = (agent.status || '').trim();
-            let statusClass = 'copilot-tag';
-            let statusDisplay = '';
+            let status = (agent.status || "").trim();
+            let statusClass = "copilot-tag";
+            let statusDisplay = "";
+            const showStatus = isInternal(agent.name, agent.address);
             if (/^yes/i.test(status)) {
-                statusClass += ' copilot-tag-green';
-                statusDisplay = `Active${agent.expiration ? ` (${escapeHtml(agent.expiration)})` : ''}`;
+                statusClass += " copilot-tag-green";
+                statusDisplay = `Active${agent.expiration ? ` (${escapeHtml(agent.expiration)})` : ""}`;
             } else if (/resigned|staged for resignatio/i.test(status) || expired) {
-                statusClass += ' copilot-tag-red';
-                statusDisplay = `Resigned${agent.expiration ? ` (${escapeHtml(agent.expiration)})` : ''}`;
+                statusClass += " copilot-tag-red";
+                statusDisplay = `Resigned${agent.expiration ? ` (${escapeHtml(agent.expiration)})` : ""}`;
             } else if (status && !/no service/i.test(status)) {
-                statusDisplay = `${status}${agent.expiration ? ` (${escapeHtml(agent.expiration)})` : ''}`;
+                statusDisplay = `${status}${agent.expiration ? ` (${escapeHtml(agent.expiration)})` : ""}`;
             }
             const statusHtml = statusDisplay ? `<span class="${statusClass}">${escapeHtml(statusDisplay)}</span>`
                                               : '<span style="color:#aaa">-</span>';
@@ -718,7 +719,7 @@
             <div class="white-box" style="margin-bottom:10px">
                 <div><b>${renderCopy(agent.name)}</b></div>
                 <div>${renderAddress(agent.address, isVAAddress(agent.address))}</div>
-                <div>${statusHtml}</div>
+                ${showStatus ? `<div>${statusHtml}</div>` : ""}
             </div>`;
         }
         // DIRECTORS / MEMBERS


### PR DESCRIPTION
## Summary
- update DB sidebar to show agent subscription status only when Incfile is the RA
- document the change in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c73b9f22083269d0414052b618518