### PR TITLE
Add Quick Actions cancel helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ information scraped from the current page.
 - Displays a sidebar on order detail pages.
 - Scrapes company, agent and officer data and presents it in a compact layout.
 - Addresses are clickable to open a Google search and copy the text.
+- Provides a Quick Actions menu with a **Cancel** option that resolves active issues and opens the cancellation dialog with the reason preselected.
 
 ## Known limitations
 

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -62,7 +62,7 @@
                             </div>
                             <button id="copilot-close">✕</button>
                         </div>
-                        <div class="order-summary-header">ORDER SUMMARY <span id="qs-toggle" class="quick-summary-toggle">⚡</span></div>
+                        <div class="order-summary-header"><span id="qa-toggle" class="quick-actions-toggle">☰</span>ORDER SUMMARY <span id="qs-toggle" class="quick-summary-toggle">⚡</span></div>
                         <div class="copilot-body" id="copilot-body-content">
                             <div style="text-align:center; color:#888; margin-top:20px;">Cargando resumen...</div>
                         </div>
@@ -92,6 +92,36 @@
                                 qsBox.classList.remove('quick-summary-collapsed');
                                 qsBox.style.maxHeight = qsBox.scrollHeight + 'px';
                             }
+                        });
+                    }
+
+                    const qaToggle = sidebar.querySelector('#qa-toggle');
+                    if (qaToggle) {
+                        const qaMenu = document.createElement('div');
+                        qaMenu.id = 'quick-actions-menu';
+                        qaMenu.style.display = 'none';
+                        qaMenu.innerHTML = '<div class="qa-title">QUICK ACTIONS</div><ul><li id="qa-cancel">Cancel</li></ul>';
+                        document.body.appendChild(qaMenu);
+
+                        qaToggle.addEventListener('click', (e) => {
+                            e.stopPropagation();
+                            qaMenu.style.display = qaMenu.style.display === 'block' ? 'none' : 'block';
+                            if (qaMenu.style.display === 'block') {
+                                const rect = qaToggle.getBoundingClientRect();
+                                qaMenu.style.top = rect.bottom + 'px';
+                                qaMenu.style.left = (rect.left - qaMenu.offsetWidth + rect.width) + 'px';
+                            }
+                        });
+
+                        document.addEventListener('click', (e) => {
+                            if (!qaMenu.contains(e.target) && e.target !== qaToggle) {
+                                qaMenu.style.display = 'none';
+                            }
+                        });
+
+                        qaMenu.querySelector('#qa-cancel').addEventListener('click', () => {
+                            qaMenu.style.display = 'none';
+                            startCancelProcedure();
                         });
                     }
                 })();
@@ -802,6 +832,52 @@
         }
     }
     });
+
+    function startCancelProcedure() {
+        console.log('[Copilot] Starting cancel procedure');
+
+        function resolveIfNeeded(next) {
+            const btn = Array.from(document.querySelectorAll('a'))
+                .find(a => /mark resolved/i.test(a.textContent));
+            if (btn) {
+                btn.click();
+                const check = setInterval(() => {
+                    if (document.readyState === 'complete') {
+                        clearInterval(check);
+                        next();
+                    }
+                }, 1000);
+            } else {
+                next();
+            }
+        }
+
+        function openCancelPopup() {
+            const statusBtn = document.querySelector('.btn-status-text');
+            if (!statusBtn) return console.warn('[Copilot] Status dropdown not found');
+            statusBtn.click();
+            setTimeout(() => {
+                const cancelLink = Array.from(document.querySelectorAll('.dropdown-menu a'))
+                    .find(a => /cancel\/?refund/i.test(a.textContent));
+                if (!cancelLink) return console.warn('[Copilot] Cancel option not found');
+                cancelLink.click();
+                selectReason();
+            }, 500);
+        }
+
+        function selectReason() {
+            const sel = document.querySelector('select');
+            if (!sel) return setTimeout(selectReason, 500);
+            const opt = Array.from(sel.options)
+                .find(o => /client.*cancell?ation/i.test(o.textContent));
+            if (opt) {
+                sel.value = opt.value;
+                sel.dispatchEvent(new Event('change', { bubbles: true }));
+            }
+        }
+
+        resolveIfNeeded(openCancelPopup);
+    }
 
     function getLastIssueInfo() {
         function parseRow(row) {

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -277,3 +277,40 @@
 .issue-status-resolved {
     background-color: #2ecc71;
 }
+
+#copilot-sidebar .quick-actions-toggle {
+    cursor: pointer;
+    margin-right: 6px;
+}
+
+#quick-actions-menu {
+    position: fixed;
+    background: #fff;
+    color: #000;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    padding: 8px;
+    z-index: 100000;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+    font-size: 13px;
+}
+
+#quick-actions-menu .qa-title {
+    font-weight: bold;
+    margin-bottom: 6px;
+}
+
+#quick-actions-menu ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+#quick-actions-menu li {
+    cursor: pointer;
+    padding: 2px 0;
+}
+
+#quick-actions-menu li:hover {
+    text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- add Quick Actions menu to DB sidebar
- implement automated cancel helper
- style quick actions
- document the new feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c734c10f88326af67eb9ce392f0d9