### PR TITLE
Improve DB cancel automation and icon alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ information scraped from the current page.
 - Addresses are clickable to open a Google search and copy the text.
 - Hides the agent subscription status line when RA service is not provided by Incfile.
 - Provides a Quick Actions menu with a **Cancel** option that resolves active issues and opens the cancellation dialog with the reason preselected.
+- The Quick Actions toggle icon is now vertically centered.
+- Cancel automation now detects the "Cancel / Refund" link even when spaces surround the slash.
 - Officer tags in the quick summary now show specific roles like
   **PRESIDENT**, **SECRETARY**, **TREASURER** or **VP** instead of a generic
   OFFICER label.

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -871,7 +871,7 @@
             statusBtn.click();
             setTimeout(() => {
                 const cancelLink = Array.from(document.querySelectorAll('.dropdown-menu a'))
-                    .find(a => /cancel\/?refund/i.test(a.textContent));
+                    .find(a => /cancel.*refund/i.test(a.textContent));
                 if (!cancelLink) return console.warn('[Copilot] Cancel option not found');
                 cancelLink.click();
                 selectReason();

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -207,6 +207,7 @@
 #copilot-sidebar .quick-summary-toggle {
     cursor: pointer;
     margin-left: 6px;
+    vertical-align: middle;
 }
 
 #copilot-sidebar #quick-summary {
@@ -281,6 +282,7 @@
 #copilot-sidebar .quick-actions-toggle {
     cursor: pointer;
     margin-right: 6px;
+    vertical-align: middle;
 }
 
 #quick-actions-menu {


### PR DESCRIPTION
## Summary
- center Quick Actions icon vertically
- match `Cancel / Refund` option even when spaced
- document updates in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c758c06d8832689b5dd502ef9264c