### PR TITLE
Move quick actions menu to header

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ information scraped from the current page.
 - Addresses are clickable to open a Google search and copy the text.
 - Hides the agent subscription status line when RA service is not provided by Incfile.
 - Provides a Quick Actions menu with a **Cancel** option that resolves active issues and opens the cancellation dialog with the reason preselected.
-- The Quick Actions toggle icon is now vertically centered.
+- The Quick Actions icon now sits in the header next to the close button and the menu fades in and out.
 - Cancel automation now detects the "Cancel / Refund" link even when spaces surround the slash.
 - Officer tags in the quick summary now show specific roles like
   **PRESIDENT**, **SECRETARY**, **TREASURER** or **VP** instead of a generic

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -60,9 +60,10 @@
                                 <img src="${chrome.runtime.getURL('fennec_icon.png')}" class="copilot-icon" alt="FENNEC (Prototype)" />
                                 <span>FENNEC (Prototype)</span>
                             </div>
+                            <span id="qa-toggle" class="quick-actions-toggle">☰</span>
                             <button id="copilot-close">✕</button>
                         </div>
-                        <div class="order-summary-header"><span id="qa-toggle" class="quick-actions-toggle">☰</span>ORDER SUMMARY <span id="qs-toggle" class="quick-summary-toggle">⚡</span></div>
+                        <div class="order-summary-header">ORDER SUMMARY <span id="qs-toggle" class="quick-summary-toggle">⚡</span></div>
                         <div class="copilot-body" id="copilot-body-content">
                             <div style="text-align:center; color:#888; margin-top:20px;">Cargando resumen...</div>
                         </div>
@@ -103,24 +104,39 @@
                         qaMenu.innerHTML = '<div class="qa-title">QUICK ACTIONS</div><ul><li id="qa-cancel">Cancel</li></ul>';
                         document.body.appendChild(qaMenu);
 
+                        function showMenu() {
+                            qaMenu.style.display = 'block';
+                            requestAnimationFrame(() => qaMenu.classList.add('show'));
+                        }
+
+                        function hideMenu() {
+                            qaMenu.classList.remove('show');
+                            qaMenu.addEventListener('transitionend', function h() {
+                                qaMenu.style.display = 'none';
+                                qaMenu.removeEventListener('transitionend', h);
+                            }, { once: true });
+                        }
+
                         qaToggle.addEventListener('click', (e) => {
                             e.stopPropagation();
-                            qaMenu.style.display = qaMenu.style.display === 'block' ? 'none' : 'block';
                             if (qaMenu.style.display === 'block') {
+                                hideMenu();
+                            } else {
                                 const rect = qaToggle.getBoundingClientRect();
                                 qaMenu.style.top = rect.bottom + 'px';
                                 qaMenu.style.left = (rect.left - qaMenu.offsetWidth + rect.width) + 'px';
+                                showMenu();
                             }
                         });
 
                         document.addEventListener('click', (e) => {
-                            if (!qaMenu.contains(e.target) && e.target !== qaToggle) {
-                                qaMenu.style.display = 'none';
+                            if (!qaMenu.contains(e.target) && e.target !== qaToggle && qaMenu.style.display === 'block') {
+                                hideMenu();
                             }
                         });
 
                         qaMenu.querySelector('#qa-cancel').addEventListener('click', () => {
-                            qaMenu.style.display = 'none';
+                            hideMenu();
                             startCancelProcedure();
                         });
                     }

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -281,7 +281,7 @@
 
 #copilot-sidebar .quick-actions-toggle {
     cursor: pointer;
-    margin-right: 6px;
+    margin-right: 8px;
     vertical-align: middle;
 }
 
@@ -295,6 +295,14 @@
     z-index: 100000;
     box-shadow: 0 2px 6px rgba(0,0,0,0.2);
     font-size: 13px;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
+}
+
+#quick-actions-menu.show {
+    opacity: 0.95;
+    pointer-events: auto;
 }
 
 #quick-actions-menu .qa-title {


### PR DESCRIPTION
## Summary
- place Quick Actions icon in the header next to the close button
- fade the Quick Actions menu in and out at 95% opacity
- document new behavior in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c76f597708326b254630deaf11201