### PR TITLE
Isolate amendment order sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ information scraped from the current page.
 - Officer tags in the quick summary now show specific roles like
   **PRESIDENT**, **SECRETARY**, **TREASURER** or **VP** instead of a generic
   OFFICER label.
+- Amendment orders now use the same summary template as business formation
+  packages.
 
 ## Known limitations
 

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -24,6 +24,15 @@
             return true;
         }
     });
+    function getOrderType() {
+        const el = document.getElementById("ordType");
+        if (!el) return "";
+        const txt = el.innerText.trim().toLowerCase();
+        if (/amendment/.test(txt)) return "amendment";
+        if (/silver|gold|platinum/.test(txt)) return "formation";
+        return txt;
+    }
+
     chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
         if (!extensionEnabled) {
             console.log('[FENNEC] Extension disabled, skipping DB launcher.');
@@ -76,7 +85,12 @@
                         sessionStorage.setItem('copilotSidebarClosed', 'true');
                         console.log("[Copilot] Sidebar cerrado manualmente en DB.");
                     };
-                    extractAndShowData();
+                    const orderType = getOrderType();
+                    if (orderType === "amendment") {
+                        extractAndShowAmendmentData();
+                    } else {
+                        extractAndShowFormationData();
+                    }
                     const qsToggle = sidebar.querySelector('#qs-toggle');
                     const qsBox = sidebar.querySelector('#quick-summary');
                     if (qsBox) {
@@ -444,7 +458,7 @@
     }
 
 
-    function extractAndShowData() {
+    function extractAndShowFormationData() {
         // 1. COMPANY
         const companyRaw = extractSingle('#vcomp .form-body', [
             {name: 'name', label: 'company name'},
@@ -844,6 +858,12 @@
             });
         }
     }
+    }
+
+    function extractAndShowAmendmentData() {
+        extractAndShowFormationData();
+    }
+
     });
 
     function startCancelProcedure() {


### PR DESCRIPTION
## Summary
- detect order type via #ordType and dispatch sidebar rendering
- clone existing formation sidebar logic for amendments
- mention new behavior in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c777bba8083268b6ad2f4c86510ad