### PR TITLE
Enhance DB family tree view

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ information scraped from the current page.
   **PRESIDENT**, **SECRETARY**, **TREASURER** or **VP** instead of a generic
   OFFICER label.
 - Amendment order summaries now display the State ID along with formation
-  state and include a **View Family Tree** button that shows the latest
-  child orders from the parent company.
+  state and include a **Family Tree** button that toggles a compact view of the
+  parent order and its latest child orders. Each entry now shows order number,
+  type, date and status, and clicking a number opens that order in a background
+  tab.
 - Unknown order types now fall back to the standard formation view.
 - Fixed a bug that prevented the sidebar from appearing on order pages.
 

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -324,3 +324,19 @@
 #quick-actions-menu li:hover {
     text-decoration: underline;
 }
+
+/* Family tree layout */
+#family-tree-orders .ft-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2px 8px;
+    margin-bottom: 6px;
+    font-size: 12px;
+}
+#family-tree-orders .ft-link {
+    color: #1a73e8;
+    cursor: pointer;
+}
+#family-tree-orders .ft-link:hover {
+    text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- streamline `Family Tree` button appearance and functionality
- show parent and child orders in a compact grid and open orders in new tabs
- close background tab after fetching family tree data
- document the new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c9888799c832693179bf933ef1e24