### PR TITLE
Add SOS link functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ information scraped from the current page.
   parent order and its latest child orders. Each entry now shows order number,
   type, date and status, and clicking a number opens that order in a background
   tab.
+- The company name (or State ID on amendments) links to the state's SOS business
+  search page.
 - Unknown order types now fall back to the standard formation view.
 - Fixed a bug that prevented the sidebar from appearing on order pages.
 

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -182,6 +182,69 @@
 
     // ----------- FUNCIONES DE EXTRACCIÓN Y RENDER ------------
 
+    // Map of US states to their Secretary of State business search pages
+    const SOS_URLS = {
+        "Alabama": "http://sos.alabama.gov/business-entities/llcs",
+        "Alaska": "https://www.commerce.alaska.gov/web/cbpl/Corporations.aspx",
+        "Arizona": "http://ecorp.azcc.gov/",
+        "Arkansas": "http://www.sos.arkansas.gov/corps/search_all.php",
+        "California": "https://businesssearch.sos.ca.gov/",
+        "Colorado": "https://www.sos.state.co.us/biz/BusinessEntityCriteriaExt.do",
+        "Connecticut": "https://www.concord-sots.ct.gov/CONCORD/online?sn=PublicInquiry&eid=9740",
+        "Delaware": "https://icis.corp.delaware.gov/Ecorp/EntitySearch/NameSearch.aspx",
+        "District of Columbia": "https://os.dc.gov/",
+        "Florida": "http://search.sunbiz.org/Inquiry/CorporationSearch/ByName",
+        "Georgia": "http://sos.ga.gov/index.php/Corporations/creating_a_new_entity",
+        "Hawaii": "https://hbe.ehawaii.gov/documents/search.html?mobile=N&site_preference=normal",
+        "Idaho": "https://sos.idaho.gov/corp/index.html",
+        "Illinois": "http://www.cyberdriveillinois.com/departments/business_services/corp.html",
+        "Indiana": "https://inbiz.in.gov/BOS/BusinssEntity/StartMyBusiness",
+        "Iowa": "https://sos.iowa.gov/search/business/search.aspx",
+        "Kansas": "https://www.kansas.gov/bess/flow/main?execution=e2s2",
+        "Kentucky": "http://www.sos.ky.gov/",
+        "Louisiana": "https://coraweb.sos.la.gov/CommercialSearch/CommercialSearch.aspx",
+        "Maine": "http://www.maine.gov/sos/cec/corp/",
+        "Maryland": "https://egov.maryland.gov/BusinessExpress/EntitySearch",
+        "Massachusetts": "http://corp.sec.state.ma.us/corpweb/CorpSearch/CorpSearch.aspx",
+        "Michigan": "http://www.dleg.state.mi.us/bcs_corp/sr_corp.asp",
+        "Minnesota": "https://mblsportal.sos.state.mn.us/Business/Search",
+        "Mississippi": "https://corp.sos.ms.gov/corp/portal/c/page/corpBusinessIdSearch/portal.aspx?#clear=1",
+        "Missouri": "https://bsd.sos.mo.gov/businessentity/besearch.aspx?searchtype=0",
+        "Montana": "https://biz.sosmt.gov/search/business",
+        "Nebraska": "https://www.nebraska.gov/sos/corp/corpsearch.cgi?nav=search",
+        "Nevada": "https://nvsos.gov/",
+        "New Hampshire": "https://quickstart.sos.nh.gov/online/BusinessInquire",
+        "New Jersey": "http://www.nj.gov/treasury/revenue/searchfile.shtml",
+        "New Mexico": "https://portal.sos.state.nm.us/BFS/online/CorporationBusinessSearch",
+        "New York": "https://appext20.dos.ny.gov/corp_public/corpsearch.entity_search_entry",
+        "North Carolina": "https://www.sosnc.gov/search/index/corp",
+        "North Dakota": "http://sos.nd.gov/business/business-services/business-records-search/business-record-search-name-availability",
+        "Ohio": "https://www5.sos.state.oh.us:8443/ords/f?p=100:1:0:::::",
+        "Oklahoma": "https://www.sos.ok.gov/corp/corpInquiryFind.aspx",
+        "Oregon": "http://egov.sos.state.or.us/br/pkg_web_name_srch_inq.login",
+        "Pennsylvania": "https://www.corporations.pa.gov/search/CorpSearch",
+        "Rhode Island": "http://ucc.state.ri.us/CorpSearch/CorpSearchInput.asp",
+        "South Carolina": "https://businessfilings.sc.gov/BusinessFiling/Entity/Search",
+        "South Dakota": "https://sosenterprise.sd.gov/BusinessServices/Business/NameAvailability.aspx",
+        "Tennessee": "https://tnbear.tn.gov/Ecommerce/FilingSearch.aspx",
+        "Texas": "https://mycpa.cpa.state.tx.us/coa/Index.html",
+        "Utah": "https://secure.utah.gov/bes/",
+        "Vermont": "https://www.sec.state.vt.us/corporationsbusiness-services/searches-databases/business-search.aspx",
+        "Virginia": "https://sccefile.scc.virginia.gov/Find/Business",
+        "Washington": "https://www.sos.wa.gov/corps/corps_search.aspx",
+        "West Virginia": "http://apps.sos.wv.gov/business/corporations/",
+        "Wisconsin": "https://www.wdfi.org/apps/CorpSearch/Search.aspx",
+        "Wyoming": "https://wyobiz.wy.gov/Business/FilingSearch.aspx",
+    };
+
+    function buildSosUrl(state, query) {
+        const base = SOS_URLS[state];
+        if (!base) return null;
+        if (!query) return base;
+        const sep = base.includes('?') ? '&' : '?';
+        return base + sep + 'q=' + encodeURIComponent(query);
+    }
+
     function escapeHtml(text) {
         return text
             .replace(/&/g, "&amp;")
@@ -774,9 +837,19 @@
                 addrHtml = `<div>${renderAddress(company.address, isVAAddress(company.address))}</div>`;
             }
             const companyLines = [];
-            companyLines.push(`<div><b>${renderCopy(company.name)}</b></div>`);
+            let nameHtml = renderCopy(company.name);
+            const nameUrl = buildSosUrl(company.state, company.name);
+            if (nameUrl) {
+                nameHtml = `<a href="${nameUrl}" target="_blank">${nameHtml}</a>`;
+            }
+            companyLines.push(`<div><b>${nameHtml}</b></div>`);
             if (isAmendment) {
-                companyLines.push(`<div>${company.stateId || '<span style="color:#aaa">-</span>'}</div>`);
+                let idHtml = company.stateId ? renderCopy(company.stateId) : '<span style="color:#aaa">-</span>';
+                const idUrl = buildSosUrl(company.state, company.stateId);
+                if (company.stateId && idUrl) {
+                    idHtml = `<a href="${idUrl}" target="_blank">${idHtml}</a>`;
+                }
+                companyLines.push(`<div>${idHtml}</div>`);
                 companyLines.push(`<div>${company.state || '<span style="color:#aaa">-</span>'}</div>`);
             } else {
                 companyLines.push(`<div>${company.state || '<span style="color:#aaa">-</span>'}</div>`);

--- a/manual-test.js
+++ b/manual-test.js
@@ -6,3 +6,4 @@ console.log("3. Select this project folder.");
 console.log("4. Visit Gmail or the DB order detail pages to check the sidebar.");
 console.log("5. Verify the sidebar is absent on other sites.");
 console.log("6. Open the browser console and confirm there are no errors.");
+console.log("7. Click the company name or State ID in the DB sidebar and ensure it opens the state's SOS search page in a new tab.");


### PR DESCRIPTION
## Summary
- make company name or state ID open the state's SOS search page
- map every US state to its SOS URL
- document feature and update manual test instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c98a1f7d883268d52c4de36ffdba7