### PR TITLE
Ensure sidebar reappears after page reload

### DIFF
--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1,5 +1,9 @@
 // Injects the FENNEC sidebar into DB pages.
 (function main() {
+    // Clear the closed flag on reloads so the sidebar reappears
+    window.addEventListener('beforeunload', () => {
+        sessionStorage.removeItem('copilotSidebarClosed');
+    });
     let currentOrderType = null;
 
     // Map of US states to their Secretary of State business search pages

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1,5 +1,9 @@
 // Injects the FENNEC sidebar into Gmail pages.
 (function persistentSidebar() {
+    // Clear the closed flag on full reloads so the sidebar returns
+    window.addEventListener('beforeunload', () => {
+        sessionStorage.removeItem('copilotSidebarClosed');
+    });
     chrome.runtime.onMessage.addListener((msg) => {
         if (msg.action === 'fennecToggle') {
             window.location.reload();


### PR DESCRIPTION
## Summary
- clear the `copilotSidebarClosed` flag when the page unloads
- applies to both Gmail and DB launchers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cadc730f483268fe4dff2ed64bfb4