### PR TITLE
Fix Gmail sidebar injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ information scraped from the current page.
 - Uses `margin-right` to ensure Gmail navigation controls stay visible.
 - The top header bar shifts left along with the main panels so account menus remain accessible.
 - If you close the sidebar it will remain hidden until the tab is reloaded.
+- The Gmail script now runs in all frames so the sidebar appears even when the
+  interface is embedded in nested iframes.
 - When opening an order, the sidebar shows the **latest issue** from the DB page.
   A label indicates whether it is **active** (red) or **resolved** (green). If no
   issue is found, the box still appears with a link to the order. The script

--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,7 @@
       "matches": [
         "https://mail.google.com/*"
       ],
+      "all_frames": true,
       "js": [
         "environments/gmail/gmail_launcher.js"
       ],


### PR DESCRIPTION
## Summary
- load Gmail content script in all frames so nested iframes also get the sidebar
- document the behavior change in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684caf78a9c08326b882d681065a84ec