### PR TITLE
Fix amendment address links

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ information scraped from the current page.
 - Amendment summaries now include an **Amendment Details** section. Addresses in
   this area are clickable with a USPS lookup icon, and names throughout the
   summary open a Google search when clicked.
+- When a line mixes description text with an address after a colon, only the
+  address portion is turned into a link so the preceding text remains plain.
 - Unknown order types now fall back to the standard formation view.
 - Fixed a bug that prevented the sidebar from appearing on order pages.
 - Resolved a `ReferenceError` in the DB sidebar by defining `SOS_URLS` at

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -304,6 +304,14 @@
         if (!text) return '';
         const lines = text.split(/\n+/).map(l => l.trim()).filter(Boolean);
         return lines.map(l => {
+            const idx = l.indexOf(':');
+            if (idx !== -1) {
+                const before = l.slice(0, idx + 1);
+                const after = l.slice(idx + 1).trim();
+                if (isAddressLine(after)) {
+                    return `<div>${escapeHtml(before)} ${renderAddress(after)}</div>`;
+                }
+            }
             if (isAddressLine(l)) {
                 return `<div>${renderAddress(l)}</div>`;
             }


### PR DESCRIPTION
## Summary
- refine address detection so only the address portion becomes a link
- document the new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68509b7873748326abc5dcda1e3f947f