### PR TITLE
Refine amendment address detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ information scraped from the current page.
   summary open a Google search when clicked.
 - When a line mixes description text with an address after a colon, only the
   address portion is turned into a link so the preceding text remains plain.
+- Partial addresses lacking a state or ZIP code now appear in **bold** and link
+  to a Google search instead of showing the USPS icon.
 - Unknown order types now fall back to the standard formation view.
 - Fixed a bug that prevented the sidebar from appearing on order pages.
 - Resolved a `ReferenceError` in the DB sidebar by defining `SOS_URLS` at


### PR DESCRIPTION
## Summary
- support partial vs full address detection when rendering amendment details
- show partial addresses in bold with a Google search link
- document partial address behavior in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850a01c18088326819f85557ee826b3