### PR TITLE
Improve address detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ information scraped from the current page.
   address portion is turned into a link so the preceding text remains plain.
 - Partial addresses lacking a state or ZIP code now appear in **bold** and link
   to a Google search instead of showing the USPS icon.
+- Address detection recognizes abbreviations like "Fls" or "Bit" and street
+  numbers with trailing letters (e.g. `22Y`).
 - Unknown order types now fall back to the standard formation view.
 - Fixed a bug that prevented the sidebar from appearing on order pages.
 - Resolved a `ReferenceError` in the DB sidebar by defining `SOS_URLS` at

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -307,7 +307,7 @@
     }
 
     function highlightAddresses(text) {
-        const re = /\b\d+[^.,\n]*?(?:street|st\.|road|rd\.|ave\.|avenue|drive|dr\.|lane|ln\.|boulevard|blvd|pkwy|parkway|court|ct\.|hwy|highway)[^.,\n]*/gi;
+        const re = /\b\d[\w-]*[^.\n]*?(?:street|st\.?|road|rd\.?|ave\.?|avenue|drive|dr\.?|lane|ln\.?|boulevard|blvd\.?|pkwy|parkway|court|ct\.?|hwy|highway|way|loop|circle|cir\.?|place|pl\.?|trail|trl\.?|point|pt\.?|falls?|fls?|bit)[^.\n]*/gi;
         let out = '';
         let last = 0;
         for (let m; (m = re.exec(text)); ) {
@@ -326,7 +326,7 @@
 
     function isAddressLine(line) {
         if (!line) return false;
-        const addrRegex = /(street|st\.|road|rd\.|ave\.|avenue|drive|dr\.|lane|ln\.|boulevard|blvd|pkwy|parkway|court|ct\.|hwy|highway)/i;
+        const addrRegex = /(street|st\.?|road|rd\.?|ave\.?|avenue|drive|dr\.?|lane|ln\.?|boulevard|blvd\.?|pkwy|parkway|court|ct\.?|hwy|highway|way|loop|circle|cir\.?|place|pl\.?|trail|trl\.?|point|pt\.?|falls?|fls?|bit)/i;
         return addrRegex.test(line) && /\d/.test(line);
     }
 


### PR DESCRIPTION
## Summary
- expand regex to detect addresses with abbreviations like `Fls` or `Bit`
- allow street numbers with trailing letters
- document new address parsing capability in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850a23657b4832694cd797b607f31ef