### PR TITLE
Adjust refresh button layout and restore quick summary toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ information scraped from the current page.
   sidebar (Company, Agent, Members/Directors, Shareholders, Officers and
   Amendment Details) right below the Issue section.
 - While the Issue section loads, a small blinking Fennec icon is shown.
-- A **REFRESH** button at the bottom reloads the sidebar data.
+- A **REFRESH** button at the end of the sidebar content reloads the data.
 - Closing the sidebar leaves a floating Fennec icon to reopen it.
 - The action buttons sit side by side and the old Potential Intel box has
   been removed.
@@ -55,7 +55,7 @@ information scraped from the current page.
 - Hides the agent subscription status line when RA service is not provided by Incfile.
 - Provides a Quick Actions menu with a **Cancel** option that resolves active issues and opens the cancellation dialog with the reason preselected.
 - The Quick Actions icon now sits in the header next to the close button and the menu fades in and out.
-- A **REFRESH** button at the bottom reloads the summary.
+- A **REFRESH** button at the end of the summary reloads the data.
 - Closing the sidebar leaves a floating Fennec icon to reopen it.
 - Cancel automation now detects the "Cancel / Refund" link even when spaces surround the slash.
 - Officer tags in the quick summary now show specific roles like

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -5,6 +5,7 @@
         sessionStorage.removeItem('copilotSidebarClosed');
     });
     let currentOrderType = null;
+    let initQuickSummary = null;
 
     function showFloatingIcon() {
         if (document.getElementById("fennec-floating-icon")) return;
@@ -175,9 +176,9 @@
                         <div class="order-summary-header">ORDER SUMMARY <span id="qs-toggle" class="quick-summary-toggle">⚡</span></div>
                         <div class="copilot-body" id="copilot-body-content">
                             <div style="text-align:center; color:#888; margin-top:20px;">Cargando resumen...</div>
-                        </div>
-                        <div class="copilot-footer">
-                            <button id="copilot-refresh" class="copilot-button">🔄 REFRESH</button>
+                            <div class="copilot-footer">
+                                <button id="copilot-refresh" class="copilot-button">🔄 REFRESH</button>
+                            </div>
                         </div>
                     `;
                     document.body.appendChild(sidebar);
@@ -198,19 +199,24 @@
                         extractAndShowFormationData();
                     }
                     const qsToggle = sidebar.querySelector('#qs-toggle');
-                    const qsBox = sidebar.querySelector('#quick-summary');
-                    if (qsBox) {
-                        qsBox.style.maxHeight = '0';
-                        qsBox.classList.add('quick-summary-collapsed');
-                    }
-                    if (qsToggle && qsBox) {
+                    initQuickSummary = () => {
+                        const box = sidebar.querySelector('#quick-summary');
+                        if (box) {
+                            box.style.maxHeight = '0';
+                            box.classList.add('quick-summary-collapsed');
+                        }
+                    };
+                    initQuickSummary();
+                    if (qsToggle) {
                         qsToggle.addEventListener('click', () => {
-                            if (qsBox.style.maxHeight && qsBox.style.maxHeight !== '0px') {
-                                qsBox.style.maxHeight = '0';
-                                qsBox.classList.add('quick-summary-collapsed');
+                            const box = sidebar.querySelector('#quick-summary');
+                            if (!box) return;
+                            if (box.style.maxHeight && box.style.maxHeight !== '0px') {
+                                box.style.maxHeight = '0';
+                                box.classList.add('quick-summary-collapsed');
                             } else {
-                                qsBox.classList.remove('quick-summary-collapsed');
-                                qsBox.style.maxHeight = qsBox.scrollHeight + 'px';
+                                box.classList.remove('quick-summary-collapsed');
+                                box.style.maxHeight = box.scrollHeight + 'px';
                             }
                         });
                     }
@@ -1091,6 +1097,7 @@
         const body = document.getElementById('copilot-body-content');
         if (body) {
             body.innerHTML = html;
+            if (typeof initQuickSummary === 'function') initQuickSummary();
             body.querySelectorAll('.copilot-address').forEach(el => {
                 el.addEventListener('click', e => {
                     e.preventDefault();

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -582,9 +582,9 @@
                         <div id="issue-summary-content" style="color:#ccc; font-size:13px;">No issue data yet.</div>
                     </div>
                     <div id="db-summary-section"></div>
-                </div>
-                <div class="copilot-footer">
-                    <button id="copilot-refresh" class="copilot-button">🔄 REFRESH</button>
+                    <div class="copilot-footer">
+                        <button id="copilot-refresh" class="copilot-button">🔄 REFRESH</button>
+                    </div>
                 </div>
             `;
             document.body.appendChild(sidebar);

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -356,11 +356,13 @@
     vertical-align: middle;
 }
 .copilot-footer {
-    padding: 10px 18px;
-    border-top: 1px solid #444;
+    margin-top: 10px;
+    text-align: center;
 }
 .copilot-footer .copilot-button {
-    width: 100%;
+    width: auto;
+    padding: 4px 10px;
+    font-size: 12px;
 }
 #fennec-floating-icon {
     position: fixed;


### PR DESCRIPTION
## Summary
- relocate refresh buttons inside sidebar scroll area and shrink size
- reset quick summary after sidebar refresh
- document updated button position in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853077c74248326ad782c2088f5af39