### PR TITLE
Fix Gmail document preview padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ information scraped from the current page.
   by falling back to `textContent` when detecting the order type.
 - Fixed a `ReferenceError` when loading amendment summaries by defining
   state abbreviation lists before they are used.
+- Fixed missing padding when previewing attachments in Gmail so documents
+  remain fully visible.
 
 ## Known limitations
 

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1,4 +1,5 @@
 // Injects the FENNEC sidebar into Gmail pages.
+// Pads main panels and the attachment viewer so content stays visible.
 (function persistentSidebar() {
     // Clear the closed flag on full reloads so the sidebar returns
     window.addEventListener('beforeunload', () => {
@@ -21,7 +22,8 @@
             const candidates = [
                 ...Array.from(document.body.querySelectorAll(':scope > .nH')),
                 ...Array.from(document.body.querySelectorAll('.aeF')),
-                ...Array.from(document.body.querySelectorAll('.Bk'))
+                ...Array.from(document.body.querySelectorAll('.Bk')),
+                ...Array.from(document.body.querySelectorAll('div[role="dialog"]'))
             ];
 
             // También ajustamos la barra superior de Gmail


### PR DESCRIPTION
## Summary
- pad Gmail attachment viewer so the doc stays fully visible
- document the fix in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685308035b8c8326934df49b4bbaeb4b