### PR TITLE
Fix DB modal overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ information scraped from the current page.
   state abbreviation lists before they are used.
 - Fixed missing padding when previewing attachments in Gmail so documents
   remain fully visible.
+- Fixed sidebar layering so the DB "View all / Add Issue" modal is not
+  obscured.
 
 ## Known limitations
 

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -5,7 +5,7 @@
     height: 100vh;
     background: #212121;
     color: #fff;
-    z-index: 99999;
+    z-index: 1030;
     box-shadow: -2px 0 16px rgba(0,0,0,0.22);
     display: flex;
     flex-direction: column;
@@ -305,7 +305,7 @@
     border: 1px solid #ccc;
     border-radius: 4px;
     padding: 8px;
-    z-index: 100000;
+    z-index: 1035;
     box-shadow: 0 2px 6px rgba(0,0,0,0.2);
     font-size: 13px;
     opacity: 0;
@@ -379,6 +379,6 @@
     right: 20px;
     width: 40px;
     height: 40px;
-    z-index: 100000;
+    z-index: 1030;
     cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- lower sidebar z-index so issue modal is clickable
- keep quick actions menu above sidebar
- document the fix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685309f75f6c8326bcd76072a9f92181