### PR TITLE
Fix stale Gmail sidebar data

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ information scraped from the current page.
 - Adds a sidebar with **EMAIL SEARCH** and **OPEN ORDER** buttons.
 - Extracts order number, sender email and name from the open email.
 - The order number parser is tolerant to common formats (e.g. with `#`, parentheses or spaces).
-- Displays a small order summary inside the sidebar.
+- Displays a small order summary only after you click **EMAIL SEARCH** or
+  **OPEN ORDER**, so old details no longer appear automatically.
 - Opens Gmail search and the DB order page in new tabs when clicking the buttons.
 - Uses `margin-right` to ensure Gmail navigation controls stay visible.
 - The top header bar shifts left along with the main panels so account menus remain accessible.

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -521,6 +521,7 @@
         function handleEmailSearchClick() {
             const context = extractOrderContextFromEmail();
             fillOrderSummaryBox(context);
+            loadDbSummary();
 
             if (!context || !context.email) {
                 alert("No se pudo detectar el correo del cliente.");
@@ -592,9 +593,8 @@
             document.body.appendChild(sidebar);
             console.log("[Copilot] Sidebar INYECTADO en Gmail.");
 
-            const ctx = extractOrderContextFromEmail();
-            fillOrderSummaryBox(ctx);
-            loadDbSummary();
+            // Start with empty boxes. Details load after the user interacts
+            // with EMAIL SEARCH or OPEN ORDER.
 
             // Botón de cierre
             document.getElementById('copilot-close').onclick = () => {
@@ -677,6 +677,9 @@
                         alert("No se encontró ningún número de orden válido en el correo.");
                         return;
                     }
+                    const context = extractOrderContextFromEmail();
+                    fillOrderSummaryBox(context);
+                    loadDbSummary();
                     const url = `https://db.incfile.com/incfile/order/detail/${orderId}`;
                     chrome.runtime.sendMessage({ action: "replaceTabs", urls: [url] });
                     checkLastIssue(orderId);


### PR DESCRIPTION
## Summary
- keep the Gmail sidebar empty on open
- load order info only after clicking **EMAIL SEARCH** or **OPEN ORDER**
- document the new behavior in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68530d8243f88326acd322d49e417740