### PR TITLE
Fix DB sidebar menu and add Emails action

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ information scraped from the current page.
 - Scrapes company, agent and officer data and presents it in a compact layout.
 - Addresses are clickable to open a Google search and copy the text.
 - Hides the agent subscription status line when RA service is not provided by Incfile.
-- Provides a Quick Actions menu with a **Cancel** option that resolves active issues and opens the cancellation dialog with the reason preselected.
+- Provides a Quick Actions menu with **Emails** and **Cancel** options. **Emails** opens a Google search for the order, client email and name while **Cancel** resolves active issues and opens the cancellation dialog with the reason preselected.
 - The Quick Actions icon now sits in the header next to the close button and the menu fades in and out.
 - A **REFRESH** button at the end of the summary reloads the data.
 - Closing the sidebar leaves a floating Fennec icon to reopen it.

--- a/core/background_emailsearch.js
+++ b/core/background_emailsearch.js
@@ -9,6 +9,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         });
     }
 
+    if (message.action === "openActiveTab" && message.url) {
+        console.log("[Copilot] Forzando apertura de una pestaña activa:", message.url);
+        chrome.tabs.create({ url: message.url, active: true }, (tab) => {
+            if (chrome.runtime.lastError) {
+                console.error("[Copilot] Error (openActiveTab):", chrome.runtime.lastError.message);
+            }
+        });
+    }
+
     if (message.action === "openTabs" && Array.isArray(message.urls)) {
         console.log("[Copilot] Forzando apertura de múltiples pestañas:", message.urls);
         message.urls.forEach((url, i) => {

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -15,7 +15,7 @@
 .copilot-header {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-start;
     padding: 12px;
     background: #c6c6c6;
     color: #000;
@@ -37,6 +37,7 @@
 #copilot-close {
     background: none; border: none; color: #000; font-size: 20px;
     cursor: pointer; outline: none;
+    margin-left: 8px;
 }
 .copilot-body {
     flex: 1;


### PR DESCRIPTION
## Summary
- tweak header layout so the hamburger icon and close button align
- fix quick actions menu placement
- add new **Emails** option that opens a Google search for the order, client email and name
- support opening an active tab from the background script
- document Emails action in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685318752d64832693e463d7b2e0ff23