### PR TITLE
Add Gmail search to DB quick actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ information scraped from the current page.
 - Scrapes company, agent and officer data and presents it in a compact layout.
 - Addresses are clickable to open a Google search and copy the text.
 - Hides the agent subscription status line when RA service is not provided by Incfile.
-- Provides a Quick Actions menu with **Emails** and **Cancel** options. **Emails** opens a Google search for the order, client email and name while **Cancel** resolves active issues and opens the cancellation dialog with the reason preselected.
+- Provides a Quick Actions menu with **Emails** and **Cancel** options. **Emails** now opens a Gmail search for the order number, client email and name while **Cancel** resolves active issues and opens the cancellation dialog with the reason preselected.
 - The Quick Actions icon now sits in the header next to the close button and the menu fades in and out.
 - A **REFRESH** button at the end of the summary reloads the data.
 - Closing the sidebar leaves a floating Fennec icon to reopen it.

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -281,9 +281,16 @@
                             hideMenu();
                             const info = getBasicOrderInfo();
                             const client = getClientInfo();
-                            const terms = [info.orderId, client.email, client.name].filter(Boolean).join(' ');
-                            if (terms) {
-                                const url = 'https://www.google.com/search?q=' + encodeURIComponent(terms);
+                            const parts = [];
+                            if (info.orderId) {
+                                parts.push(info.orderId);
+                                parts.push(`subject:"${info.orderId}"`);
+                            }
+                            if (client.email) parts.push(`"${client.email}"`);
+                            if (client.name) parts.push(`"${client.name}"`);
+                            if (parts.length) {
+                                const query = parts.map(p => encodeURIComponent(p)).join('+OR+');
+                                const url = 'https://mail.google.com/mail/u/0/#search/' + query;
                                 chrome.runtime.sendMessage({ action: 'openActiveTab', url });
                             }
                         });


### PR DESCRIPTION
## Summary
- open Gmail search from Quick Actions menu in DB sidebar
- note the Gmail search behaviour in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68531a93076c832687aadd9bf9679a43