### PR TITLE
Extend family tree to more order types

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ information scraped from the current page.
   view of the parent order and its latest child orders. Each entry now shows order number,
   type, date and status, and clicking a number opens that order in a background
   tab.
+- The family tree icon also appears on Annual Report, Foreign Qualification,
+  Virtual Address and Registered Agent orders.
 - The company name (or State ID on amendments) links to the state's SOS business
   search page.
 - Amendment summaries now include an **Amendment Details** section. Addresses in

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -134,7 +134,7 @@
         const txt = (el.textContent || "").trim().toLowerCase();
         if (/amendment/.test(txt)) return "amendment";
         if (/silver|gold|platinum/.test(txt)) return "formation";
-        return "formation";
+        return "other";
     }
 
     chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
@@ -202,7 +202,7 @@
                     currentOrderType = orderType;
                     const ftIcon = sidebar.querySelector('#family-tree-icon');
                     if (ftIcon) {
-                        ftIcon.style.display = orderType === 'amendment' ? 'inline' : 'none';
+                        ftIcon.style.display = orderType !== 'formation' ? 'inline' : 'none';
                     }
                     if (orderType === "amendment") {
                         extractAndShowAmendmentData();


### PR DESCRIPTION
## Summary
- show the family tree icon for any order that isn't a formation
- return `other` for non-formation order types
- document that Annual Report, Foreign Qualification, Virtual Address and Registered Agent orders support the family tree icon

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68531e3c452c832694295f20bd8d51b1