### PR TITLE
Improve open order button setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ information scraped from the current page.
 - Uses `margin-right` to ensure Gmail navigation controls stay visible.
 - The top header bar shifts left along with the main panels so account menus remain accessible.
 - If you close the sidebar it will remain hidden until the tab is reloaded.
+- The **OPEN ORDER** button keeps working if you close and reopen the sidebar.
 - The Gmail script now runs in all frames so the sidebar appears even when the
   interface is embedded in nested iframes.
 - When opening an order, the sidebar shows the **latest issue** from the DB page.

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -620,6 +620,7 @@
                 loadDbSummary();
                 if (ctx && ctx.orderNumber) checkLastIssue(ctx.orderNumber);
             };
+            setupOpenOrderButton();
         }
 
         function injectSidebarIfMissing() {
@@ -647,7 +648,7 @@
             }
         });
 
-        // --- OPEN ORDER listener robusto, sin cambios ---
+        // --- OPEN ORDER listener reutilizable ---
         function waitForElement(selector, timeout = 10000) {
             return new Promise((resolve, reject) => {
                 const intervalTime = 100;
@@ -667,7 +668,9 @@
             });
         }
 
-        waitForElement("#btn-open-order").then((button) => {
+        function setupOpenOrderButton() {
+            const button = document.getElementById("btn-open-order");
+            if (!button) return;
             button.addEventListener("click", function () {
                 try {
                     const bodyNode = document.querySelector(".a3s");
@@ -694,6 +697,10 @@
                     alert("Ocurrió un error al intentar abrir la orden.");
                 }
             });
+        }
+
+        waitForElement("#btn-open-order").then(() => {
+            setupOpenOrderButton();
         }).catch((err) => {
             console.warn("[OPEN ORDER] No se pudo inyectar el listener:", err);
         });


### PR DESCRIPTION
## Summary
- refactor Gmail launcher to reuse open order click handler
- attach open order listener each time the sidebar is injected
- document sidebar reliability in README

## Testing
- `node manual-test.js`

------
https://chatgpt.com/codex/tasks/task_e_68532ee840ec8326b49de0a82f09c368