### PR TITLE
Improve link behavior in sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ information scraped from the current page.
 - Displays a sidebar on order detail pages.
 - Scrapes company, agent and officer data and presents it in a compact layout.
 - Addresses are clickable to open a Google search and copy the text.
+- The company purpose also opens a Google search. Addresses and the purpose text are only underlined on hover.
 - Hides the agent subscription status line when RA service is not provided by Incfile.
 - Provides a Quick Actions menu with **Emails** and **Cancel** options. **Emails** now opens a Gmail search for the order number, client email and name while **Cancel** resolves active issues and opens the cancellation dialog with the reason preselected.
 - The Quick Actions icon now sits in the header next to the close button and the menu fades in and out.
@@ -86,7 +87,7 @@ information scraped from the current page.
   search page.
 - Amendment summaries now include an **Amendment Details** section. Addresses in
   this area are clickable with a USPS lookup icon, and names throughout the
-  summary open a Google search when clicked.
+  summary now copy to the clipboard when clicked.
 - When a line mixes description text with an address after a colon, only the
   address portion is turned into a link so the preceding text remains plain.
 - Partial addresses lacking a state or ZIP code now appear in **bold** and link

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -380,8 +380,7 @@
     function renderName(text) {
         if (!text) return '<span style="color:#aaa">-</span>';
         const esc = escapeHtml(text);
-        const url = 'https://www.google.com/search?q=' + encodeURIComponent(text);
-        return `<a href="${url}" target="_blank" class="copilot-copy copilot-name" data-copy="${esc}">${esc}</a>`;
+        return `<span class="copilot-copy copilot-name" data-copy="${esc}">${esc}</span>`;
     }
 
 
@@ -1170,9 +1169,10 @@
             });
             body.querySelectorAll('.copilot-name').forEach(el => {
                 el.addEventListener('click', e => {
+                    e.preventDefault();
                     const text = el.dataset.copy;
                     if (!text) return;
-                    window.open('https://www.google.com/search?q=' + encodeURIComponent(text), '_blank');
+                    navigator.clipboard.writeText(text).catch(err => console.warn('[Copilot] Clipboard', err));
                 });
             });
             const ftIcon = document.getElementById('family-tree-icon');

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -109,6 +109,7 @@
 .copilot-address {
     color: #1a73e8;
     cursor: pointer;
+    text-decoration: none;
 }
 .copilot-address:hover {
     text-decoration: underline;


### PR DESCRIPTION
## Summary
- prevent addresses from being underlined by default
- make RA and other name links copy to clipboard instead of opening search
- note new behavior in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68542a3c7bbc8326af5d0fb94778ea74