### PR TITLE
Improve family tree panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,12 @@ information scraped from the current page.
   tab.
 - The family tree icon also appears on Annual Report, Foreign Qualification,
   Virtual Address and Registered Agent orders.
-- Beneath the tree list there is an **AR DIAGNOSE** button that opens all
+- Beneath the tree list there is an **🩺 DIAGNOSE** button that opens all
   child orders with a HOLD status in background tabs.
+- The family tree panel now slides open with the same animation as the Quick
+  Summary and is positioned directly below it. Status labels are color coded
+  (green for **SHIPPED**, **REVIEW** or **PROCESSING**, red for **CANCELED**, purple
+  for **HOLD**) and the button reads **🩺 DIAGNOSE**.
 - Fixed detection of the parent order so the tree icon functions on all
   non-formation orders.
 - Fixed missing summary container so the tree icon now opens the parent

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -351,6 +351,22 @@
     margin-bottom: 6px;
     font-size: 12px;
 }
+#family-tree-orders {
+    overflow: hidden;
+    max-height: 0;
+    transition: max-height 0.3s ease;
+}
+#family-tree-orders.ft-collapsed {
+    margin-bottom: 0 !important;
+    padding: 0 !important;
+}
+#family-tree-orders .section-label {
+    text-align: center;
+}
+#family-tree-orders .ft-type,
+#family-tree-orders .ft-date {
+    font-size: 11px;
+}
 #family-tree-orders .ft-link {
     color: #1a73e8;
     cursor: pointer;


### PR DESCRIPTION
## Summary
- animate the family tree panel like the Quick Summary and show it right below
- colour-code family tree statuses and use a stethoscope icon for DIAGNOSE
- show package type for parent order and unify date formatting
- adjust styles for tree layout
- document updated tree behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68543445aab083268261dbae0bd28395