### PR TITLE
Improve knowledge base link order type detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ information scraped from the current page.
   to the clipboard.
 - Clicking the state name now opens the Filing Department knowledge base in a new
   tab and navigates automatically to the matching article for that order type.
+- Order type detection now recognizes Business Formation packages, Foreign
+  Qualification, Amendments, Registered Agent Change and Annual Report (including
+  alternate names like Business Entity Report, Biennial Report or Renewal).
 - Host permissions for every SOS search site are included so the query can be
   injected automatically when those pages open.
 - Updated the West Virginia SOS link and host permission so searches work again.

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -291,6 +291,37 @@
         return "other";
     }
 
+    function normalizeOrderType(text) {
+        const t = (text || "").toLowerCase();
+        if (t.includes("amendment")) return "Amendment";
+        if (t.includes("foreign") && t.includes("qualification")) {
+            return "Foreign Qualification";
+        }
+        if (t.includes("registered agent") && t.includes("change")) {
+            return "Registered Agent Change";
+        }
+        const annual = [
+            "annual report",
+            "business entity report",
+            "biennial report",
+            "information report",
+            "annual statement",
+            "annual registration report",
+            "annual list",
+            "annual certificate",
+            "renewal",
+            "public information report",
+            "pir",
+            "registration fee"
+        ];
+        if (annual.some(k => t.includes(k))) return "Annual Report";
+        if (t.includes("silver")) return "Business Formation - Silver";
+        if (t.includes("gold")) return "Business Formation - Gold";
+        if (t.includes("platinum")) return "Business Formation - Platinum";
+        if (t.includes("formation")) return "Business Formation";
+        return text;
+    }
+
     chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
         if (!extensionEnabled) {
             console.log('[FENNEC] Extension disabled, skipping DB launcher.');
@@ -354,7 +385,8 @@
                     }
                     const orderType = getOrderType();
                     currentOrderType = orderType;
-                    currentOrderTypeText = getText(document.getElementById('ordType')) || '';
+                    const rawType = getText(document.getElementById('ordType')) || '';
+                    currentOrderTypeText = normalizeOrderType(rawType);
                     const ftIcon = sidebar.querySelector('#family-tree-icon');
                     if (ftIcon) {
                         ftIcon.style.display = orderType !== 'formation' ? 'inline' : 'none';


### PR DESCRIPTION
## Summary
- detect order types such as formation packages, Foreign Qualification, Amendments, Annual Report aliases and Registered Agent Change
- open knowledge base with normalized order types
- document new detection behavior in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854649b32ec8326b5e197d086047d84