### PR TITLE
Handle DB storage pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ information scraped from the current page.
   overview on Annual Report, Foreign Qualification, Certificate of Good
   Standing, Reinstatement, Dissolution and Virtual Address orders.
 - Works on DB sandbox subdomains by building links from the current origin.
+- The sidebar also remains visible on document storage pages, reusing the last
+  order summary.
 - The company name (or State ID on amendments) links to the state's SOS business
   search page. Clicking either now opens the search form, fills in the value and
   automatically runs the query.
@@ -137,7 +139,7 @@ information scraped from the current page.
 
 - The scripts rely on the browser DOM provided by Chrome. They are not meant to
   run under Node.js or outside the browser context.
-- The extension currently supports only Gmail and DB order detail URLs.
+- The extension currently supports Gmail plus DB order detail and storage URLs.
 
 ## Development
 

--- a/manifest.json
+++ b/manifest.json
@@ -12,6 +12,7 @@
   "host_permissions": [
     "https://mail.google.com/*",
     "https://*.incfile.com/incfile/order/detail/*",
+    "https://*.incfile.com/storage/incfile/*",
     "https://tools.usps.com/*",
     "https://apps.dfi.wi.gov/*",
     "https://apps.dos.ny.gov/*",
@@ -80,7 +81,8 @@
     },
     {
       "matches": [
-        "https://*.incfile.com/incfile/order/detail/*"
+        "https://*.incfile.com/incfile/order/detail/*",
+        "https://*.incfile.com/storage/incfile/*"
       ],
       "js": [
         "environments/db/db_launcher.js"

--- a/popup.js
+++ b/popup.js
@@ -12,6 +12,7 @@ function saveState() {
     const urls = [
       'https://mail.google.com/*',
       'https://*.incfile.com/incfile/order/detail/*',
+      'https://*.incfile.com/storage/incfile/*',
       'https://tools.usps.com/*'
     ];
 


### PR DESCRIPTION
## Summary
- support DB document storage pages
- load stored order data on storage pages
- keep extension toggle working on storage pages
- document new storage page support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854663c285c8326b152864f5f93f2d9