### PR TITLE
Update floating icon behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ information scraped from the current page.
 - Numbered requirements in the Issue text are shown on separate lines for clarity.
 - While the Issue section loads, a small blinking Fennec icon is shown.
 - A **REFRESH** button at the end of the sidebar content reloads the data.
-- Closing the sidebar leaves a floating Fennec icon to reopen it.
+ - Closing the sidebar leaves a floating Fennec icon in the upper right corner to reopen it. Reopening refreshes the sidebar with the current email.
 - The action buttons sit side by side and the old Potential Intel box has
   been removed.
 - The **EMAIL SEARCH** and **OPEN ORDER** buttons are now smaller so they
@@ -63,7 +63,7 @@ information scraped from the current page.
 - Provides a Quick Actions menu with **Emails** and **Cancel** options. **Emails** now opens a Gmail search for the order number, client email and name while **Cancel** resolves active issues and opens the cancellation dialog with the reason preselected.
 - The Quick Actions icon now sits in the header next to the close button and the menu fades in and out.
 - A **REFRESH** button at the end of the summary reloads the data.
-- Closing the sidebar leaves a floating Fennec icon to reopen it.
+ - Closing the sidebar leaves a floating Fennec icon in the upper right corner to reopen it. Reopening refreshes the sidebar with the current order.
 - Cancel automation now detects the "Cancel / Refund" link even when spaces surround the slash.
 - The Cancel quick action resumes automatically after the page refreshes when resolving an issue.
 - Officer tags in the quick summary now show specific roles like

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -60,6 +60,7 @@
                 sessionStorage.removeItem("copilotSidebarClosed");
                 const panels = applyPaddingToMainPanels();
                 injectSidebar(panels);
+                refreshSidebar();
             });
             document.body.appendChild(icon);
         }
@@ -549,6 +550,13 @@
             });
         }
 
+        function refreshSidebar() {
+            const ctx = extractOrderContextFromEmail();
+            fillOrderSummaryBox(ctx);
+            loadDbSummary();
+            if (ctx && ctx.orderNumber) checkLastIssue(ctx.orderNumber);
+        }
+
         function handleEmailSearchClick() {
             const context = extractOrderContextFromEmail();
             fillOrderSummaryBox(context);
@@ -639,12 +647,7 @@
 
             // Botón EMAIL SEARCH (listener UNIFICADO)
             document.getElementById("btn-email-search").onclick = handleEmailSearchClick;
-            document.getElementById("copilot-refresh").onclick = () => {
-                const ctx = extractOrderContextFromEmail();
-                fillOrderSummaryBox(ctx);
-                loadDbSummary();
-                if (ctx && ctx.orderNumber) checkLastIssue(ctx.orderNumber);
-            };
+            document.getElementById("copilot-refresh").onclick = refreshSidebar;
             setupOpenOrderButton();
         }
 

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -405,7 +405,7 @@
 }
 #fennec-floating-icon {
     position: fixed;
-    bottom: 20px;
+    top: 20px;
     right: 20px;
     width: 40px;
     height: 40px;


### PR DESCRIPTION
## Summary
- move floating reopen icon to upper right corner
- refresh Gmail sidebar when reopened
- document new reopen behavior in README

## Testing
- `node manual-test.js`

------
https://chatgpt.com/codex/tasks/task_e_6854686100d483268f97f6867933d8bc