### PR TITLE
Improve DB summary persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ information scraped from the current page.
 - Fixed sidebar layering so the DB "View all / Add Issue" modal is not
   obscured.
 - Fixed a crash when the **Refresh** button listener failed to attach on some DB pages.
+- Stored DB summaries now include the order number so the sidebar on storage pages only displays matching data.
 - A separator line now appears between addresses and the RA/VA tags in the quick summary, and those tags are repeated at the bottom of the Company section. Fields showing `N/A` or blank values are omitted, and shareholders display their share count prefixed with "Shares:".
 - Sections lacking meaningful details now show **NO INFO** instead of being hidden.
 - Officer and Shareholder sections are omitted for LLC orders.

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -37,8 +37,9 @@
     function loadStoredSummary() {
         const body = document.getElementById('copilot-body-content');
         if (!body) return;
-        chrome.storage.local.get({ sidebarDb: [] }, ({ sidebarDb }) => {
-            if (Array.isArray(sidebarDb) && sidebarDb.length) {
+        const currentId = getBasicOrderInfo().orderId;
+        chrome.storage.local.get({ sidebarDb: [], sidebarOrderId: null }, ({ sidebarDb, sidebarOrderId }) => {
+            if (Array.isArray(sidebarDb) && sidebarDb.length && sidebarOrderId && sidebarOrderId === currentId) {
                 body.innerHTML = sidebarDb.join('');
             } else {
                 body.innerHTML = '<div style="text-align:center; color:#aaa; margin-top:40px">No DB data.</div>';
@@ -1401,7 +1402,8 @@
             html = `<div style="text-align:center; color:#aaa; margin-top:40px">No se encontró información relevante de la orden.</div>`;
         }
 
-        chrome.storage.local.set({ sidebarDb: dbSections });
+        const orderInfo = getBasicOrderInfo();
+        chrome.storage.local.set({ sidebarDb: dbSections, sidebarOrderId: orderInfo.orderId });
 
         const body = document.getElementById('copilot-body-content');
         if (body) {

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -494,11 +494,11 @@
             });
         }
 
-        function loadDbSummary() {
+        function loadDbSummary(expectedId) {
             const container = document.getElementById('db-summary-section');
             if (!container) return;
-            chrome.storage.local.get({ sidebarDb: [] }, ({ sidebarDb }) => {
-                if (Array.isArray(sidebarDb) && sidebarDb.length) {
+            chrome.storage.local.get({ sidebarDb: [], sidebarOrderId: null }, ({ sidebarDb, sidebarOrderId }) => {
+                if (Array.isArray(sidebarDb) && sidebarDb.length && (!expectedId || sidebarOrderId === expectedId)) {
                     container.innerHTML = sidebarDb.join('');
                     attachCommonListeners(container);
                 } else {
@@ -553,14 +553,14 @@
         function refreshSidebar() {
             const ctx = extractOrderContextFromEmail();
             fillOrderSummaryBox(ctx);
-            loadDbSummary();
+            loadDbSummary(ctx && ctx.orderNumber);
             if (ctx && ctx.orderNumber) checkLastIssue(ctx.orderNumber);
         }
 
         function handleEmailSearchClick() {
             const context = extractOrderContextFromEmail();
             fillOrderSummaryBox(context);
-            loadDbSummary();
+            loadDbSummary(context && context.orderNumber);
 
             if (!context || !context.email) {
                 alert("No se pudo detectar el correo del cliente.");
@@ -716,7 +716,7 @@
                     }
                     const context = extractOrderContextFromEmail();
                     fillOrderSummaryBox(context);
-                    loadDbSummary();
+                    loadDbSummary(context && context.orderNumber);
                     const url = `https://db.incfile.com/incfile/order/detail/${orderId}`;
                     chrome.runtime.sendMessage({ action: "replaceTabs", urls: [url] });
                     checkLastIssue(orderId);


### PR DESCRIPTION
## Summary
- save the current order id alongside the DB sidebar data
- only show saved DB info when it matches the page order
- allow Gmail to check for matching order when loading DB data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68546badae5c8326b298df20dfbb648b