### PR TITLE
Address display uses three lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ information scraped from the current page.
   to a Google search instead of showing the USPS icon.
 - Address detection recognizes abbreviations like "Fls" or "Bit" and street
   numbers with trailing letters (e.g. `22Y`).
+- Street addresses with two lines now appear across three lines to keep the city
+  and state separate.
 - Unknown order types now fall back to the standard formation view.
 - Fixed a bug that prevented the sidebar from appearing on order pages.
 - Resolved a `ReferenceError` in the DB sidebar by defining `SOS_URLS` at

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -573,16 +573,20 @@
         const parts = addr.split(/,\s*/);
 
         let firstLine = parts.shift() || '';
-        let secondLine = parts.join(', ');
+        let secondLine = '';
+        let rest = '';
 
-        if (parts.length > 2) {
-            const extra = parts.shift();
-            firstLine = `${firstLine}, ${extra}`;
-            secondLine = parts.join(', ');
+        if (parts.length > 1) {
+            secondLine = parts.shift();
+            rest = parts.join(', ');
+        } else {
+            rest = parts.join(', ');
         }
 
-        const display = secondLine ? `${escapeHtml(firstLine)}<br>${escapeHtml(secondLine)}`
-                                    : escapeHtml(firstLine);
+        const lines = [firstLine];
+        if (secondLine) lines.push(secondLine);
+        if (rest) lines.push(rest);
+        const display = lines.map(escapeHtml).join('<br>');
         const escFull = escapeHtml(addr);
         const extra = isVA
             ? ` <span class="copilot-tag copilot-tag-green">VA</span>`

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -252,16 +252,20 @@
             const parts = addr.split(/,\s*/);
 
             let firstLine = parts.shift() || '';
-            let secondLine = parts.join(', ');
+            let secondLine = '';
+            let rest = '';
 
-            if (parts.length > 2) {
-                const extra = parts.shift();
-                firstLine = `${firstLine}, ${extra}`;
-                secondLine = parts.join(', ');
+            if (parts.length > 1) {
+                secondLine = parts.shift();
+                rest = parts.join(', ');
+            } else {
+                rest = parts.join(', ');
             }
 
-            const display = secondLine ? `${escapeHtml(firstLine)}<br>${escapeHtml(secondLine)}`
-                                        : escapeHtml(firstLine);
+            const lines = [firstLine];
+            if (secondLine) lines.push(secondLine);
+            if (rest) lines.push(rest);
+            const display = lines.map(escapeHtml).join('<br>');
             const escFull = escapeHtml(addr);
             return `<span class="address-wrapper"><a href="#" class="copilot-address" data-address="${escFull}">${display}</a><span class="copilot-usps" data-address="${escFull}" title="USPS Lookup"> ✉️</span></span>`;
         }


### PR DESCRIPTION
## Summary
- support optional second street line in address renderer
- support multi-line addresses in Gmail sidebar renderer
- document address layout change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68546eaf26b88326a08328f24dda1cff