### PR TITLE
Improve address line formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ information scraped from the current page.
 - Address detection recognizes abbreviations like "Fls" or "Bit" and street
   numbers with trailing letters (e.g. `22Y`).
 - Street addresses with two lines now appear across three lines to keep the city
-  and state separate.
+  and state separate. Addresses with only one street line are shown on two
+  lines.
 - Unknown order types now fall back to the standard formation view.
 - Fixed a bug that prevented the sidebar from appearing on order pages.
 - Resolved a `ReferenceError` in the DB sidebar by defining `SOS_URLS` at

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -572,11 +572,11 @@
         if (!isValidField(addr)) return '';
         const parts = addr.split(/,\s*/);
 
-        let firstLine = parts.shift() || '';
+        const firstLine = parts.shift() || '';
         let secondLine = '';
         let rest = '';
 
-        if (parts.length > 1) {
+        if (parts.length > 2) {
             secondLine = parts.shift();
             rest = parts.join(', ');
         } else {

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -251,11 +251,11 @@
             addr = cleanAddress(addr);
             const parts = addr.split(/,\s*/);
 
-            let firstLine = parts.shift() || '';
+            const firstLine = parts.shift() || '';
             let secondLine = '';
             let rest = '';
 
-            if (parts.length > 1) {
+            if (parts.length > 2) {
                 secondLine = parts.shift();
                 rest = parts.join(', ');
             } else {


### PR DESCRIPTION
## Summary
- keep second line out of addresses unless more than two comma-separated parts
- display two-line addresses correctly in Gmail and DB
- document address formatting nuance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685471b1db808326afbf5e4ce6da333c