### PR TITLE
Map order type for KB links

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ information scraped from the current page.
   to the clipboard.
 - Clicking the state name now opens the Filing Department knowledge base in a new
   tab and navigates automatically to the matching article for that order type.
+- The order type label sent to the knowledge base now maps formation packages to
+  **Main Orders** and amendments to **Amendments**.
 - Order type detection now recognizes Business Formation packages, Foreign
   Qualification, Amendments, Registered Agent Change and Annual Report (including
   alternate names like Business Entity Report, Biennial Report or Renewal).

--- a/core/background_emailsearch.js
+++ b/core/background_emailsearch.js
@@ -255,7 +255,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                         let tries = 40;
                         const run = () => {
                             if (clickStateAnchor(state)) {
-                                if (type) setTimeout(() => clickExact(type), 500);
+                                if (type) {
+                                    let typeTries = 40;
+                                    const tryType = () => {
+                                        if (!clickExact(type) && typeTries-- > 0) {
+                                            setTimeout(tryType, 500);
+                                        }
+                                    };
+                                    setTimeout(tryType, 500);
+                                }
                             } else if (tries-- > 0) {
                                 setTimeout(run, 500);
                             }

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -335,6 +335,13 @@
         return text;
     }
 
+    function mapKbCategory(text) {
+        const t = (text || "").toLowerCase();
+        if (t.includes("business formation")) return "Main Orders";
+        if (t.includes("amendment")) return "Amendments";
+        return text;
+    }
+
     chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
         if (!extensionEnabled) {
             console.log('[FENNEC] Extension disabled, skipping DB launcher.');
@@ -615,7 +622,7 @@
     function renderKb(state) {
         if (!isValidField(state)) return '<span style="color:#aaa">-</span>';
         const esc = escapeHtml(state);
-        const type = currentOrderTypeText ? currentOrderTypeText : '';
+        const type = currentOrderTypeText ? mapKbCategory(currentOrderTypeText) : '';
         return `<a href="#" class="copilot-kb" data-state="${esc}" data-otype="${escapeHtml(type)}">${esc}</a>`;
     }
 


### PR DESCRIPTION
## Summary
- map DB order type text to Coda knowledge base category names
- show the mapped KB label when rendering a KB link
- retry clicking the KB article type when opening the knowledge base
- document KB order type mapping in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68548cfa19dc832697fba6bada36c96a