### PR TITLE
Add HOLD diagnosis overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ information scraped from the current page.
 - The family tree icon also appears on Annual Report, Foreign Qualification,
   Virtual Address and Registered Agent orders.
 - Beneath the tree list there is an **🩺 DIAGNOSE** button that opens all
-  child orders with a HOLD status in background tabs.
+ child orders with a HOLD status in background tabs. After the pages load the
+ extension reads the latest issue on each one and shows a floating summary on
+ the parent order with the order number, type, status and issue text. If no
+ issue is present the summary displays who placed the order on hold.
 - The family tree panel now slides open with the same animation as the Quick
   Summary and is positioned directly below it. Status labels are color coded
   (green for **SHIPPED**, **REVIEW** or **PROCESSING**, red for **CANCELED**, purple

--- a/core/background_emailsearch.js
+++ b/core/background_emailsearch.js
@@ -110,6 +110,51 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         return true;
     }
 
+    if (message.action === "checkHoldUser" && message.orderId) {
+        const orderId = message.orderId;
+        const query = { url: `https://db.incfile.com/incfile/order/detail/${orderId}*` };
+        let attempts = 15;
+        let delay = 1000;
+
+        const tryFetch = () => {
+            chrome.tabs.query(query, (tabs) => {
+                const tab = tabs && tabs[0];
+                if (!tab || tab.status !== "complete") {
+                    if (attempts > 0) {
+                        setTimeout(() => {
+                            attempts--;
+                            delay = Math.min(delay * 1.5, 10000);
+                            tryFetch();
+                        }, delay);
+                    } else {
+                        console.warn(`[Copilot] Hold user check timed out for order ${orderId}`);
+                        sendResponse({ holdUser: null });
+                    }
+                    return;
+                }
+                chrome.tabs.sendMessage(tab.id, { action: "getHoldUser" }, (resp) => {
+                    if (chrome.runtime.lastError) {
+                        if (attempts > 0) {
+                            setTimeout(() => {
+                                attempts--;
+                                delay = Math.min(delay * 1.5, 10000);
+                                tryFetch();
+                            }, delay);
+                        } else {
+                            console.warn(`[Copilot] Hold user check timed out for order ${orderId}`);
+                            sendResponse({ holdUser: null });
+                        }
+                        return;
+                    }
+                    sendResponse(resp);
+                });
+            });
+        };
+
+        tryFetch();
+        return true;
+    }
+
     if (message.action === "fetchChildOrders" && message.orderId) {
         const orderId = message.orderId;
         let base = "https://db.incfile.com";

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -294,6 +294,12 @@
             }
             return true;
         }
+        if (msg.action === 'getHoldUser') {
+            getLastHoldUser().then(user => {
+                sendResponse({ holdUser: user });
+            });
+            return true;
+        }
     });
     function getOrderType() {
         const el = document.getElementById("ordType");
@@ -1556,12 +1562,11 @@
                         if (diagBtn) {
                             diagBtn.addEventListener('click', () => {
                                 const holds = resp.childOrders.filter(o => /hold/i.test(o.status));
-                                if (holds.length) {
-                                    const urls = holds.map(o => `${location.origin}/incfile/order/detail/${o.orderId}`);
-                                    chrome.runtime.sendMessage({ action: 'openTabs', urls });
-                                } else {
+                                if (!holds.length) {
                                     alert('No HOLD orders found');
+                                    return;
                                 }
+                                diagnoseHoldOrders(holds);
                             });
                         }
                     });
@@ -1750,5 +1755,91 @@
             }
         }
         return { name: '', email: '' };
+    }
+
+    function diagnoseHoldOrders(orders) {
+        const urls = orders.map(o => `${location.origin}/incfile/order/detail/${o.orderId}`);
+        chrome.runtime.sendMessage({ action: 'openTabs', urls });
+        const promises = orders.map(o => new Promise(res => {
+            chrome.runtime.sendMessage({ action: 'checkLastIssue', orderId: o.orderId }, issueResp => {
+                if (issueResp && issueResp.issueInfo) {
+                    res({ order: o, issue: issueResp.issueInfo.text, active: issueResp.issueInfo.active });
+                } else {
+                    chrome.runtime.sendMessage({ action: 'checkHoldUser', orderId: o.orderId }, holdResp => {
+                        const user = holdResp && holdResp.holdUser ? `On hold by ${holdResp.holdUser}` : 'On hold';
+                        res({ order: o, issue: user, active: true });
+                    });
+                }
+            });
+        }));
+        Promise.all(promises).then(showDiagnoseResults);
+    }
+
+    function showDiagnoseResults(results) {
+        let overlay = document.getElementById('fennec-diagnose-overlay');
+        if (overlay) overlay.remove();
+        overlay = document.createElement('div');
+        overlay.id = 'fennec-diagnose-overlay';
+        const close = document.createElement('div');
+        close.className = 'diag-close';
+        close.textContent = '✕';
+        close.addEventListener('click', () => overlay.remove());
+        overlay.appendChild(close);
+        results.forEach(r => {
+            const card = document.createElement('div');
+            card.className = 'diag-card';
+            const cls =
+                /shipped|review|processing/i.test(r.order.status) ? 'copilot-tag copilot-tag-green' :
+                /canceled/i.test(r.order.status) ? 'copilot-tag copilot-tag-red' :
+                /hold/i.test(r.order.status) ? 'copilot-tag copilot-tag-purple' : 'copilot-tag';
+            card.innerHTML =
+                `<div><b>${escapeHtml(r.order.orderId)}</b></div>` +
+                `<div class="ft-type">${escapeHtml(r.order.type).toUpperCase()}</div>` +
+                `<div><span class="${cls}">${escapeHtml(r.order.status)}</span></div>` +
+                `<div>${escapeHtml(r.issue)}</div>`;
+            overlay.appendChild(card);
+        });
+        document.body.appendChild(overlay);
+    }
+
+    function getLastHoldUser() {
+        const trigger = document.querySelector("a[onclick*='modalTrackOrderHistory']");
+        if (trigger) trigger.click();
+        let attempts = 10;
+        const parse = () => {
+            const rows = Array.from(document.querySelectorAll('#modalTrackOrderHistory table tbody tr'));
+            for (const row of rows) {
+                const cells = row.querySelectorAll('td');
+                if (cells.length >= 2 && /hold status/i.test(cells[1].textContent)) {
+                    const s = row.querySelector('strong');
+                    if (s) return s.textContent.trim();
+                }
+            }
+            const items = Array.from(document.querySelectorAll('#modalTrackOrderHistory .sl-item'));
+            for (const item of items) {
+                const link = item.querySelector('a');
+                if (link && /hold status/i.test(link.textContent)) {
+                    const date = item.querySelector('.sl-date');
+                    if (date) {
+                        const parts = date.textContent.split('-');
+                        if (parts.length > 1) return parts.pop().trim();
+                    }
+                }
+            }
+            return null;
+        };
+        return new Promise(resolve => {
+            const check = () => {
+                const user = parse();
+                if (user || attempts-- <= 0) {
+                    const closeBtn = document.querySelector('#modalTrackOrderHistory .close');
+                    if (closeBtn) closeBtn.click();
+                    resolve(user);
+                } else {
+                    setTimeout(check, 500);
+                }
+            };
+            check();
+        });
     }
 })();

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -412,3 +412,37 @@
     z-index: 1060;
     cursor: pointer;
 }
+
+#fennec-diagnose-overlay {
+    position: fixed;
+    top: 80px;
+    right: 20px;
+    background: #fff;
+    color: #000;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    padding: 8px;
+    z-index: 1065;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+    font-size: 13px;
+}
+
+#fennec-diagnose-overlay .diag-close {
+    position: absolute;
+    top: 4px;
+    right: 6px;
+    cursor: pointer;
+    font-weight: bold;
+}
+
+#fennec-diagnose-overlay .diag-card {
+    display: inline-block;
+    vertical-align: top;
+    width: 160px;
+    margin: 4px;
+    padding: 6px;
+    border: 1px solid #eee;
+    border-radius: 4px;
+    background: #fafafa;
+    text-align: center;
+}


### PR DESCRIPTION
## Summary
- show a floating overlay when using the DIAGNOSE button
- fetch latest issue or hold user for each HOLD child order
- style diagnose overlay
- document new DIAGNOSE behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68548de8534c8326882d24892012a80f