### PR TITLE
Fix diagnose overlay on subdomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ information scraped from the current page.
   overview on Annual Report, Foreign Qualification, Certificate of Good
   Standing, Reinstatement, Dissolution and Virtual Address orders.
 - Works on DB sandbox subdomains by building links from the current origin.
+- Fixed diagnose summary not appearing on sandbox subdomains by using the
+  current origin when checking child orders.
 - The sidebar also remains visible on document storage pages, reusing the last
   order summary.
 - The company name (and State ID when present) links to the state's SOS business

--- a/core/background_emailsearch.js
+++ b/core/background_emailsearch.js
@@ -67,7 +67,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     if (message.action === "checkLastIssue" && message.orderId) {
         const orderId = message.orderId;
-        const query = { url: `https://db.incfile.com/incfile/order/detail/${orderId}*` };
+        let base = "https://db.incfile.com";
+        if (sender && sender.tab && sender.tab.url) {
+            try {
+                base = new URL(sender.tab.url).origin;
+            } catch (err) {
+                console.warn("[Copilot] Invalid sender URL", sender.tab.url);
+            }
+        }
+        const query = { url: `${base}/incfile/order/detail/${orderId}*` };
         let attempts = 15;
         let delay = 1000;
 
@@ -112,7 +120,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     if (message.action === "checkHoldUser" && message.orderId) {
         const orderId = message.orderId;
-        const query = { url: `https://db.incfile.com/incfile/order/detail/${orderId}*` };
+        let base = "https://db.incfile.com";
+        if (sender && sender.tab && sender.tab.url) {
+            try {
+                base = new URL(sender.tab.url).origin;
+            } catch (err) {
+                console.warn("[Copilot] Invalid sender URL", sender.tab.url);
+            }
+        }
+        const query = { url: `${base}/incfile/order/detail/${orderId}*` };
         let attempts = 15;
         let delay = 1000;
 


### PR DESCRIPTION
## Summary
- use the current tab origin when checking hold orders
- document diagnose overlay fix in README

## Testing
- `node manual-test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685490f35e808326b58dd8036069c60b