### PR TITLE
Improve DIAGNOSE overlay layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,11 @@ information scraped from the current page.
   Virtual Address and Registered Agent orders.
 - Beneath the tree list there is an **🩺 DIAGNOSE** button that opens all
  child orders with a HOLD status in background tabs. After the pages load the
- extension reads the latest issue on each one and shows a floating summary on
- the parent order with the order number, type, status and issue text. If no
- issue is present the summary displays who placed the order on hold.
+ extension reads the latest issue on each one and shows a centered floating
+ summary on the parent order. Each card now displays a clickable order number
+ with the type in parentheses, the colored status tag and the latest issue
+ text. If no issue is present the summary displays who placed the order on
+ hold.
 - The family tree panel now slides open with the same animation as the Quick
   Summary and is positioned directly below it. Status labels are color coded
   (green for **SHIPPED**, **REVIEW** or **PROCESSING**, red for **CANCELED**, purple

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1800,16 +1800,17 @@
                 /canceled/i.test(r.order.status) ? "copilot-tag copilot-tag-red" :
                 /hold/i.test(r.order.status) ? "copilot-tag copilot-tag-purple" : "copilot-tag";
 
-            const idDiv = document.createElement("div");
-            const b = document.createElement("b");
-            b.textContent = r.order.orderId;
-            idDiv.appendChild(b);
-            card.appendChild(idDiv);
-
-            const typeDiv = document.createElement("div");
-            typeDiv.className = "ft-type";
-            typeDiv.textContent = r.order.type.toUpperCase();
-            card.appendChild(typeDiv);
+            const line = document.createElement("div");
+            const link = document.createElement("a");
+            link.href = `${location.origin}/incfile/order/detail/${r.order.orderId}`;
+            link.target = "_blank";
+            link.textContent = r.order.orderId;
+            line.appendChild(link);
+            const typeSpan = document.createElement("span");
+            typeSpan.className = "ft-type";
+            typeSpan.textContent = ` (${r.order.type.toUpperCase()})`;
+            line.appendChild(typeSpan);
+            card.appendChild(line);
 
             const statusDiv = document.createElement("div");
             const statusSpan = document.createElement("span");
@@ -1819,6 +1820,7 @@
             card.appendChild(statusDiv);
 
             const issueDiv = document.createElement("div");
+            issueDiv.className = "diag-issue";
             issueDiv.textContent = r.issue;
             card.appendChild(issueDiv);
 

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -415,16 +415,17 @@
 
 #fennec-diagnose-overlay {
     position: fixed;
-    top: 80px;
-    right: 20px;
-    background: #fff;
-    color: #000;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    padding: 8px;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: #2e2e2e;
+    color: #f1f1f1;
+    border-radius: 8px;
+    padding: 12px 16px;
     z-index: 1065;
     box-shadow: 0 2px 6px rgba(0,0,0,0.2);
     font-size: 13px;
+    text-align: center;
 }
 
 #fennec-diagnose-overlay .diag-close {
@@ -433,16 +434,26 @@
     right: 6px;
     cursor: pointer;
     font-weight: bold;
+    color: #fff;
 }
 
 #fennec-diagnose-overlay .diag-card {
     display: inline-block;
     vertical-align: top;
-    width: 160px;
-    margin: 4px;
-    padding: 6px;
-    border: 1px solid #eee;
-    border-radius: 4px;
-    background: #fafafa;
+    width: 180px;
+    margin: 8px;
+    padding: 8px;
+    border-radius: 8px;
+    background: #3a3a3a;
+    color: #f1f1f1;
     text-align: center;
+}
+
+#fennec-diagnose-overlay .diag-issue {
+    background: #2e2e2e;
+    border-radius: 6px;
+    padding: 6px;
+    margin-top: 6px;
+    font-size: 12px;
+    color: #f1f1f1;
 }


### PR DESCRIPTION
## Summary
- center DIAGNOSE overlay and apply dark Fennec style
- show clickable order number with order type
- present status tag and issue text in styled cards
- document updated overlay behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685494d890308326a40212f153a25c3e