### PR TITLE
Add light mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ information scraped from the current page.
 3. Enable **Developer mode** (toggle in the top right).
 4. Click **Load unpacked** and select the project folder. The sidebar will then
    be available when visiting supported pages.
+5. Use the extension popup to enable **Light Mode** for a minimalist black and white style.
 
 ## Sidebar features
+
+- Optional **Light Mode** turns the sidebar black on white for a minimalist look.
 
 ### Gmail
 - Adds a sidebar with **EMAIL SEARCH** and **OPEN ORDER** buttons.

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -348,10 +348,15 @@
         return text;
     }
 
-    chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
+    chrome.storage.local.get({ extensionEnabled: true, lightMode: false }, ({ extensionEnabled, lightMode }) => {
         if (!extensionEnabled) {
             console.log('[FENNEC] Extension disabled, skipping DB launcher.');
             return;
+        }
+        if (lightMode) {
+            document.body.classList.add('fennec-light-mode');
+        } else {
+            document.body.classList.remove('fennec-light-mode');
         }
 
         try {

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -10,10 +10,15 @@
             window.location.reload();
         }
     });
-    chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
+    chrome.storage.local.get({ extensionEnabled: true, lightMode: false }, ({ extensionEnabled, lightMode }) => {
         if (!extensionEnabled) {
             console.log('[FENNEC] Extension disabled, skipping Gmail launcher.');
             return;
+        }
+        if (lightMode) {
+            document.body.classList.add('fennec-light-mode');
+        } else {
+            document.body.classList.remove('fennec-light-mode');
         }
         try {
             const SIDEBAR_WIDTH = 340;

--- a/manifest.json
+++ b/manifest.json
@@ -76,7 +76,8 @@
         "environments/gmail/gmail_launcher.js"
       ],
       "css": [
-        "styles/sidebar.css"
+        "styles/sidebar.css",
+        "styles/sidebar_light.css"
       ]
     },
     {
@@ -88,7 +89,8 @@
         "environments/db/db_launcher.js"
       ],
       "css": [
-        "styles/sidebar.css"
+        "styles/sidebar.css",
+        "styles/sidebar_light.css"
       ]
     },
     {

--- a/popup.html
+++ b/popup.html
@@ -13,6 +13,10 @@
     <input type="checkbox" id="extension-toggle">
     <label for="extension-toggle">Enable FENNEC</label>
   </div>
+  <div id="theme-wrapper" style="margin-top:8px; display:flex; align-items:center;">
+    <input type="checkbox" id="light-toggle" style="margin-right:8px;">
+    <label for="light-toggle">Light Mode</label>
+  </div>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,14 +1,16 @@
-// Handles enable/disable toggle
-const toggle = document.getElementById('extension-toggle');
+// Handles enable/disable toggle and light mode
+const toggle = document.getElementById("extension-toggle");
+const lightToggle = document.getElementById("light-toggle");
 
 function loadState() {
-  chrome.storage.local.get({ extensionEnabled: true }, ({ extensionEnabled }) => {
+  chrome.storage.local.get({ extensionEnabled: true, lightMode: false }, ({ extensionEnabled, lightMode }) => {
     toggle.checked = Boolean(extensionEnabled);
+    lightToggle.checked = Boolean(lightMode);
   });
 }
 
 function saveState() {
-  chrome.storage.local.set({ extensionEnabled: toggle.checked }, () => {
+  chrome.storage.local.set({ extensionEnabled: toggle.checked, lightMode: lightToggle.checked }, () => {
     const urls = [
       'https://mail.google.com/*',
       'https://*.incfile.com/incfile/order/detail/*',
@@ -34,5 +36,6 @@ function saveState() {
 
 document.addEventListener('DOMContentLoaded', () => {
   loadState();
-  toggle.addEventListener('change', saveState);
+  toggle.addEventListener("change", saveState);
+  lightToggle.addEventListener("change", saveState);
 });

--- a/styles/sidebar_light.css
+++ b/styles/sidebar_light.css
@@ -1,0 +1,35 @@
+/* Overrides for minimal black and white light mode */
+.fennec-light-mode #copilot-sidebar {
+    background: #fff;
+    color: #000;
+}
+.fennec-light-mode .copilot-header {
+    background: #000;
+    color: #fff;
+    border-bottom: 1px solid #aaa;
+}
+.fennec-light-mode .copilot-button {
+    background-color: #fff;
+    color: #000;
+    border-color: #000;
+}
+.fennec-light-mode .order-summary-box,
+.fennec-light-mode .intel-summary-box,
+.fennec-light-mode .issue-summary-box,
+.fennec-light-mode #copilot-sidebar .white-box,
+.fennec-light-mode #fennec-diagnose-overlay,
+.fennec-light-mode #fennec-diagnose-overlay .diag-card,
+.fennec-light-mode #fennec-diagnose-overlay .diag-issue {
+    background: #fff;
+    color: #000;
+}
+.fennec-light-mode .copilot-tag {
+    background-color: #000;
+    color: #fff;
+}
+.fennec-light-mode .issue-status-active {
+    background-color: #000;
+}
+.fennec-light-mode .issue-status-resolved {
+    background-color: #444;
+}


### PR DESCRIPTION
## Summary
- support a new light mode theme with a white sidebar
- let users toggle Light Mode from the popup
- apply the light theme based on stored setting
- document the new feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68557e00826c83269c743c137e44eb47