### PR TITLE
Gmail sidebar review menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ information scraped from the current page.
   been removed.
 - The **EMAIL SEARCH** and **OPEN ORDER** buttons are now smaller so they
   never exceed the sidebar width, and their default color is a softer black.
-- A new hamburger icon in the header toggles **Review Mode**. When enabled the
-  sidebar shows an extra **XRAY** button centered below **OPEN ORDER**.
+- The hamburger icon in the header now opens a small menu with a **Review Mode**
+  toggle. When enabled the sidebar shows an extra **XRAY** button and only the
+  **QUICK SUMMARY** is visible with a **Details** button to reveal the rest.
 
 ### DB
 - Displays a sidebar on order detail pages.

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -362,6 +362,30 @@
     text-decoration: underline;
 }
 
+#review-menu {
+    position: fixed;
+    background: #fff;
+    color: #000;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    padding: 8px;
+    z-index: 1035;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+    font-size: 13px;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
+}
+
+#review-menu.show {
+    opacity: 0.95;
+    pointer-events: auto;
+}
+
+#review-menu label {
+    cursor: pointer;
+}
+
 /* Family tree layout */
 #family-tree-orders .ft-grid {
     display: grid;


### PR DESCRIPTION
## Summary
- add floating menu in Gmail sidebar header
- show Quick Summary only when Review Mode is active with Details button
- style review menu
- document new Gmail sidebar behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685583da9e788326ac2618a64ed81c8d