### PR TITLE
Fix light mode text and borders

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ information scraped from the current page.
 3. Enable **Developer mode** (toggle in the top right).
 4. Click **Load unpacked** and select the project folder. The sidebar will then
    be available when visiting supported pages.
-5. Use the extension popup to enable **Light Mode** for a minimalist black and white style.
+5. Use the extension popup to enable **Light Mode** for a minimalist black and white style. All text appears in black with medium gray borders for clarity.
 
 ## Sidebar features
 
-- Optional **Light Mode** turns the sidebar black on white for a minimalist look.
+- Optional **Light Mode** turns the sidebar black on white for a minimalist look, with darker text and medium gray borders.
 
 ### Gmail
 - Adds a sidebar with **EMAIL SEARCH** and **OPEN ORDER** buttons.

--- a/styles/sidebar_light.css
+++ b/styles/sidebar_light.css
@@ -3,15 +3,18 @@
     background: #fff;
     color: #000;
 }
+.fennec-light-mode #copilot-sidebar * {
+    color: #000;
+}
 .fennec-light-mode .copilot-header {
     background: #000;
     color: #fff;
-    border-bottom: 1px solid #aaa;
+    border-bottom: 1px solid #777;
 }
 .fennec-light-mode .copilot-button {
     background-color: #fff;
     color: #000;
-    border-color: #000;
+    border: 1px solid #777;
 }
 .fennec-light-mode .order-summary-box,
 .fennec-light-mode .intel-summary-box,
@@ -22,6 +25,7 @@
 .fennec-light-mode #fennec-diagnose-overlay .diag-issue {
     background: #fff;
     color: #000;
+    border: 1px solid #777;
 }
 .fennec-light-mode .copilot-tag {
     background-color: #000;
@@ -29,7 +33,12 @@
 }
 .fennec-light-mode .issue-status-active {
     background-color: #000;
+    color: #fff;
 }
 .fennec-light-mode .issue-status-resolved {
     background-color: #444;
+    color: #fff;
+}
+.fennec-light-mode .copilot-copy-icon {
+    color: #000;
 }


### PR DESCRIPTION
## Summary
- make all light mode text black by default
- keep dark text readable on dark backgrounds
- use medium gray borders on light mode elements
- document the light mode improvements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855867758008326816fcc5db2e457e8