### PR TITLE
Fix light mode colors for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ information scraped from the current page.
 3. Enable **Developer mode** (toggle in the top right).
 4. Click **Load unpacked** and select the project folder. The sidebar will then
    be available when visiting supported pages.
-5. Use the extension popup to enable **Light Mode** for a minimalist black and white style. All text appears in black with medium gray borders for clarity.
+5. Use the extension popup to enable **Light Mode** for a minimalist black and white style. Summary text is solid black with medium gray borders, the header shows white text on a black bar and the Fennec icon appears inverted.
 
 ## Sidebar features
 
-- Optional **Light Mode** turns the sidebar black on white for a minimalist look, with darker text and medium gray borders.
+- Optional **Light Mode** turns the sidebar black on white for a minimalist look with darker summary text, a black header with white lettering and a white Fennec icon.
 
 ### Gmail
 - Adds a sidebar with **EMAIL SEARCH** and **OPEN ORDER** buttons.

--- a/styles/sidebar_light.css
+++ b/styles/sidebar_light.css
@@ -8,7 +8,7 @@
 }
 .fennec-light-mode .copilot-header {
     background: #000;
-    color: #fff;
+    color: #fff !important;
     border-bottom: 1px solid #777;
 }
 .fennec-light-mode .copilot-button {
@@ -24,7 +24,7 @@
 .fennec-light-mode #fennec-diagnose-overlay .diag-card,
 .fennec-light-mode #fennec-diagnose-overlay .diag-issue {
     background: #fff;
-    color: #000;
+    color: #000 !important;
     border: 1px solid #777;
 }
 .fennec-light-mode .copilot-tag {
@@ -41,4 +41,23 @@
 }
 .fennec-light-mode .copilot-copy-icon {
     color: #000;
+}
+
+/* Ensure header icons stay visible */
+.fennec-light-mode #copilot-close,
+.fennec-light-mode #copilot-menu {
+    color: #fff;
+}
+
+/* Darken summary text that uses inline styles */
+.fennec-light-mode #order-summary-content,
+.fennec-light-mode #issue-summary-content {
+    color: #000 !important;
+}
+
+/* Use inverted Fennec icon in light mode */
+.fennec-light-mode .copilot-icon,
+.fennec-light-mode #fennec-floating-icon,
+.fennec-light-mode .loading-fennec {
+    filter: invert(1);
 }


### PR DESCRIPTION
## Summary
- tweak light mode CSS so header text shows white on black
- force summary boxes to use black text
- keep header icons visible and invert the Fennec logo
- document the updated light mode appearance in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855884c7fb083269257071c69cfd261