### PR TITLE
Fix Diagnose button cropping

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,3 +206,5 @@ Reload the extension after editing the manifest.
   only overriding the base URL when the sender tab belongs to `incfile.com`.
 - Fixed stored DB summaries so links and copy icons work correctly on document
   pages by reattaching the sidebar listeners.
+- Fixed the **DIAGNOSE** button being cut off when expanding the Family Tree
+  panel by accounting for the box margin.

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -179,7 +179,8 @@
                     container.innerHTML = '';
                     container.appendChild(box);
                     container.dataset.loaded = 'true';
-                    container.style.maxHeight = container.scrollHeight + 'px';
+                    const extra = parseInt(box.style.marginBottom) || 0;
+                    container.style.maxHeight = (container.scrollHeight + extra) + 'px';
                     container.classList.remove('ft-collapsed');
 
                     container.querySelectorAll('.ft-link').forEach(a => {

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -454,6 +454,7 @@
     transform: translate(-50%, -50%);
     background: #2e2e2e;
     color: #f1f1f1;
+    border: 1px solid gray;
     border-radius: 8px;
     padding: 12px 16px;
     z-index: 1065;


### PR DESCRIPTION
## Summary
- account for margin when expanding the Family Tree panel so the **DIAGNOSE** button isn't cut off
- give the diagnose overlay a 1px gray border
- document fix in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68559020e9f48326ac2fff67162b8d11