### PR TITLE
Update diagnose overlay layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ information scraped from the current page.
   with a clickable order number, the colored status tag and the retrieved text.
 - The diagnose overlay now shows immediately with a loading message and updates
   each card as soon as the details are fetched.
+- Diagnose cards now display the order number in bold on the first line, followed
+  by tags for the status and order type. A red **CANCEL** tag below the issue
+  text starts the cancel procedure when clicked.
 - The family tree panel now slides open with the same animation as the Quick
   Summary and is positioned directly below it. Status labels are color coded
   (green for **SHIPPED**, **REVIEW** or **PROCESSING**, red for **CANCELED**, purple

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1801,29 +1801,35 @@
                 /canceled/i.test(r.order.status) ? 'copilot-tag copilot-tag-red' :
                 /hold/i.test(r.order.status) ? 'copilot-tag copilot-tag-purple' : 'copilot-tag';
 
-            const line = document.createElement('div');
             const link = document.createElement('a');
             link.href = `${location.origin}/incfile/order/detail/${r.order.orderId}`;
             link.target = '_blank';
             link.textContent = r.order.orderId;
-            line.appendChild(link);
-            const typeSpan = document.createElement('span');
-            typeSpan.className = 'ft-type';
-            typeSpan.textContent = ` (${r.order.type.toUpperCase()})`;
-            line.appendChild(typeSpan);
-            card.appendChild(line);
+            link.className = 'diag-order';
+            card.appendChild(link);
 
-            const statusDiv = document.createElement('div');
+            const tagsDiv = document.createElement('div');
+            tagsDiv.className = 'diag-tags';
             const statusSpan = document.createElement('span');
             statusSpan.className = cls;
             statusSpan.textContent = r.order.status;
-            statusDiv.appendChild(statusSpan);
-            card.appendChild(statusDiv);
+            tagsDiv.appendChild(statusSpan);
+            const typeSpan = document.createElement('span');
+            typeSpan.className = 'copilot-tag copilot-tag-white';
+            typeSpan.textContent = r.order.type.toUpperCase();
+            tagsDiv.appendChild(typeSpan);
+            card.appendChild(tagsDiv);
 
             const issueDiv = document.createElement('div');
             issueDiv.className = 'diag-issue';
             issueDiv.textContent = r.issue;
             card.appendChild(issueDiv);
+
+            const cancel = document.createElement('span');
+            cancel.className = 'copilot-tag copilot-tag-red diag-cancel';
+            cancel.textContent = 'CANCEL';
+            cancel.addEventListener('click', startCancelProcedure);
+            card.appendChild(cancel);
 
             overlay.appendChild(card);
         };

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -489,6 +489,23 @@
     text-align: center;
 }
 
+#fennec-diagnose-overlay .diag-order {
+    color: #fff;
+    font-weight: bold;
+    display: block;
+    margin-bottom: 4px;
+}
+
+#fennec-diagnose-overlay .diag-tags {
+    margin-bottom: 4px;
+}
+
+#fennec-diagnose-overlay .diag-cancel {
+    cursor: pointer;
+    margin-top: 6px;
+    display: inline-block;
+}
+
 #fennec-diagnose-overlay .diag-issue {
     background: #2e2e2e;
     border-radius: 6px;

--- a/styles/sidebar_light.css
+++ b/styles/sidebar_light.css
@@ -31,6 +31,16 @@
     background-color: #000;
     color: #fff;
 }
+
+.fennec-light-mode .copilot-tag-white {
+    background-color: #fff;
+    color: #000;
+    border: 1px solid #777;
+}
+
+.fennec-light-mode #fennec-diagnose-overlay .diag-order {
+    color: #000;
+}
 .fennec-light-mode .issue-status-active {
     background-color: #000;
     color: #fff;


### PR DESCRIPTION
## Summary
- refine diagnose overlay cards
- style diagnose overlay for both normal and light mode
- mention overlay layout in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685591e9557c832680ba4d2789c21777