### PR TITLE
Improve family tree reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,3 +217,5 @@ Reload the extension after editing the manifest.
   panel by accounting for the box margin.
 
 - Fixed the Family Tree panel not showing on first click by updating the max-height after adding the orders.
+- Improved Family Tree reliability on non-formation orders by opening
+  background tabs in the same window.


### PR DESCRIPTION
## Summary
- ensure new tabs open in the same window when fetching child orders
- allow openTab/openTabs to accept a window ID
- document family tree fix in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68559892518883268686c93b52fcd1f3