### PR TITLE
Fix light mode header text

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ information scraped from the current page.
 ## Sidebar features
 
 - Optional **Light Mode** turns the sidebar black on white for a minimalist look with darker summary text, a black header with white lettering and a white Fennec icon.
+- In this mode the header and tags now always display white text so they remain readable against the black background.
 
 ### Gmail
 - Adds a sidebar with **EMAIL SEARCH** and **OPEN ORDER** buttons.

--- a/styles/sidebar_light.css
+++ b/styles/sidebar_light.css
@@ -11,6 +11,11 @@
     color: #fff !important;
     border-bottom: 1px solid #777;
 }
+/* Ensure all header text stays white on the black bar */
+.fennec-light-mode .copilot-header,
+.fennec-light-mode .copilot-header * {
+    color: #fff !important;
+}
 .fennec-light-mode .copilot-button {
     background-color: #fff;
     color: #000;
@@ -29,12 +34,12 @@
 }
 .fennec-light-mode .copilot-tag {
     background-color: #000;
-    color: #fff;
+    color: #fff !important;
 }
 
 .fennec-light-mode .copilot-tag-white {
     background-color: #fff;
-    color: #000;
+    color: #000 !important;
     border: 1px solid #777;
 }
 


### PR DESCRIPTION
## Summary
- ensure header text and tag text is white in light mode
- document the improved light mode behavior in the README

## Testing
- `node manual-test.js`

------
https://chatgpt.com/codex/tasks/task_e_685598f4667c83269019999dd4571fcf