### PR TITLE
Fix family tree escapeHtml error

### DIFF
--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -48,6 +48,15 @@
             }
         });
     }
+    function escapeHtml(text) {
+        return text
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/\"/g, "&quot;")
+            .replace(/'/g, "&#039;");
+    }
+
 
     function attachCommonListeners(rootEl) {
         if (!rootEl) return;
@@ -742,14 +751,6 @@
         return base + sep + 'q=' + encodeURIComponent(query);
     }
 
-    function escapeHtml(text) {
-        return text
-            .replace(/&/g, "&amp;")
-            .replace(/</g, "&lt;")
-            .replace(/>/g, "&gt;")
-            .replace(/\"/g, "&quot;")
-            .replace(/'/g, "&#039;");
-    }
 
     function isValidField(text) {
         if (!text) return false;


### PR DESCRIPTION
## Summary
- define `escapeHtml` earlier in DB launcher so it's available before event handlers
- remove duplicate function definition

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855a2b6fa808326b5812f8288a8db2a