### PR TITLE
Fix light mode tag color

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,3 +227,4 @@ Reload the extension after editing the manifest.
   background tabs in the same window.
 - Always creates the Family Tree container if missing so the panel toggles
   reliably.
+- Fixed Light Mode tags with black backgrounds showing black text.

--- a/styles/sidebar_light.css
+++ b/styles/sidebar_light.css
@@ -48,11 +48,11 @@
 }
 .fennec-light-mode .issue-status-active {
     background-color: #000;
-    color: #fff;
+    color: #fff !important;
 }
 .fennec-light-mode .issue-status-resolved {
     background-color: #444;
-    color: #fff;
+    color: #fff !important;
 }
 .fennec-light-mode .copilot-copy-icon {
     color: #000;


### PR DESCRIPTION
## Summary
- ensure issue status tags stay readable in light mode
- document the fix in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855ab44d4d8832698ec017d3cd17064