### PR TITLE
Add Review Mode toggle in extension popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ information scraped from the current page.
   box merges the Company section and the next box is the **QUICK SUMMARY**. On
   DB pages all sections remain but a small **REVIEW MODE** label shows at the
   bottom. The same toggle is also available in the DB sidebar menu and stays in
-  sync across Gmail and DB.
+  sync across Gmail and DB. Review Mode can also be enabled from the extension
+  popup.
 
 ### DB
 - Displays a sidebar on order detail pages.

--- a/popup.html
+++ b/popup.html
@@ -17,6 +17,10 @@
     <input type="checkbox" id="light-toggle" style="margin-right:8px;">
     <label for="light-toggle">Light Mode</label>
   </div>
+  <div id="review-wrapper" style="margin-top:8px; display:flex; align-items:center;">
+    <input type="checkbox" id="review-toggle" style="margin-right:8px;">
+    <label for="review-toggle">Review Mode</label>
+  </div>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,16 +1,18 @@
-// Handles enable/disable toggle and light mode
+// Handles enable/disable toggle, light mode and review mode
 const toggle = document.getElementById("extension-toggle");
 const lightToggle = document.getElementById("light-toggle");
+const reviewToggle = document.getElementById("review-toggle");
 
 function loadState() {
-  chrome.storage.local.get({ extensionEnabled: true, lightMode: false }, ({ extensionEnabled, lightMode }) => {
+  chrome.storage.local.get({ extensionEnabled: true, lightMode: false, fennecReviewMode: false }, ({ extensionEnabled, lightMode, fennecReviewMode }) => {
     toggle.checked = Boolean(extensionEnabled);
     lightToggle.checked = Boolean(lightMode);
+    reviewToggle.checked = Boolean(fennecReviewMode);
   });
 }
 
 function saveState() {
-  chrome.storage.local.set({ extensionEnabled: toggle.checked, lightMode: lightToggle.checked }, () => {
+  chrome.storage.local.set({ extensionEnabled: toggle.checked, lightMode: lightToggle.checked, fennecReviewMode: reviewToggle.checked }, () => {
     const urls = [
       'https://mail.google.com/*',
       'https://*.incfile.com/incfile/order/detail/*',
@@ -38,4 +40,5 @@ document.addEventListener('DOMContentLoaded', () => {
   loadState();
   toggle.addEventListener("change", saveState);
   lightToggle.addEventListener("change", saveState);
+  reviewToggle.addEventListener("change", saveState);
 });


### PR DESCRIPTION
## Summary
- allow toggling Review Mode from the extension popup
- persist `fennecReviewMode` state in `chrome.storage.local`
- mention the popup toggle in README

## Testing
- `npm test`
- ❌ `google-chrome --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ba6a54a0832691b8e7e841458102