### PR TITLE
Fix light mode label colors

### DIFF
--- a/styles/sidebar_light.css
+++ b/styles/sidebar_light.css
@@ -37,6 +37,17 @@
     color: #fff !important;
 }
 
+/* Keep tags readable inside white boxes */
+.fennec-light-mode #copilot-sidebar .copilot-tag {
+    color: #fff !important;
+}
+
+/* Ensure status labels remain visible */
+.fennec-light-mode #copilot-sidebar .issue-status-label,
+.fennec-light-mode #copilot-sidebar .review-mode-label {
+    color: #fff !important;
+}
+
 .fennec-light-mode .copilot-tag-white {
     background-color: #fff;
     color: #000 !important;


### PR DESCRIPTION
## Summary
- ensure tags stay white inside white boxes in light mode
- keep issue and review labels readable when `fennec-light-mode` is active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855be62bb808326993edaf71a284a77