### PR TITLE
Add Bento Mode theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ information scraped from the current page.
 4. Click **Load unpacked** and select the project folder. The sidebar will then
    be available when visiting supported pages.
 5. Use the extension popup to enable **Light Mode** for a minimalist black and white style. Summary text is solid black with medium gray borders, the header shows white text on a black bar and the Fennec icon appears inverted.
+6. Enable **Bento Mode** from the popup to arrange the sidebar content in a colorful grid layout.
 
 ## Sidebar features
 
 - Optional **Light Mode** turns the sidebar black on white for a minimalist look with darker summary text, a black header with white lettering and a white Fennec icon.
-- In this mode the header and tags now always display white text so they remain readable against the black background.
+- In Light Mode the header and tags always display white text so they remain readable against the black background.
+- **Bento Mode** arranges the summary boxes in a two-column grid with soft pastel colors.
 
 ### Gmail
 - Adds a sidebar with **EMAIL SEARCH** and **OPEN ORDER** buttons.

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -545,7 +545,7 @@
         }
     }
 
-    chrome.storage.local.get({ extensionEnabled: true, lightMode: false, fennecReviewMode: false }, ({ extensionEnabled, lightMode, fennecReviewMode }) => {
+    chrome.storage.local.get({ extensionEnabled: true, lightMode: false, bentoMode: false, fennecReviewMode: false }, ({ extensionEnabled, lightMode, bentoMode, fennecReviewMode }) => {
         if (!extensionEnabled) {
             console.log('[FENNEC] Extension disabled, skipping DB launcher.');
             return;
@@ -554,6 +554,11 @@
             document.body.classList.add('fennec-light-mode');
         } else {
             document.body.classList.remove('fennec-light-mode');
+        }
+        if (bentoMode) {
+            document.body.classList.add('fennec-bento-mode');
+        } else {
+            document.body.classList.remove('fennec-bento-mode');
         }
 
         reviewMode = fennecReviewMode;

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -10,7 +10,7 @@
             window.location.reload();
         }
     });
-    chrome.storage.local.get({ extensionEnabled: true, lightMode: false, fennecReviewMode: false }, ({ extensionEnabled, lightMode, fennecReviewMode }) => {
+    chrome.storage.local.get({ extensionEnabled: true, lightMode: false, bentoMode: false, fennecReviewMode: false }, ({ extensionEnabled, lightMode, bentoMode, fennecReviewMode }) => {
         if (!extensionEnabled) {
             console.log('[FENNEC] Extension disabled, skipping Gmail launcher.');
             return;
@@ -19,6 +19,11 @@
             document.body.classList.add('fennec-light-mode');
         } else {
             document.body.classList.remove('fennec-light-mode');
+        }
+        if (bentoMode) {
+            document.body.classList.add('fennec-bento-mode');
+        } else {
+            document.body.classList.remove('fennec-bento-mode');
         }
         try {
             const SIDEBAR_WIDTH = 340;

--- a/manifest.json
+++ b/manifest.json
@@ -78,7 +78,8 @@
       ],
       "css": [
         "styles/sidebar.css",
-        "styles/sidebar_light.css"
+        "styles/sidebar_light.css",
+        "styles/sidebar_bento.css"
       ]
     },
     {
@@ -92,7 +93,8 @@
       ],
       "css": [
         "styles/sidebar.css",
-        "styles/sidebar_light.css"
+        "styles/sidebar_light.css",
+        "styles/sidebar_bento.css"
       ]
     },
     {

--- a/popup.html
+++ b/popup.html
@@ -17,6 +17,10 @@
     <input type="checkbox" id="light-toggle" style="margin-right:8px;">
     <label for="light-toggle">Light Mode</label>
   </div>
+  <div id="bento-wrapper" style="margin-top:8px; display:flex; align-items:center;">
+    <input type="checkbox" id="bento-toggle" style="margin-right:8px;">
+    <label for="bento-toggle">Bento Mode</label>
+  </div>
   <div id="review-wrapper" style="margin-top:8px; display:flex; align-items:center;">
     <input type="checkbox" id="review-toggle" style="margin-right:8px;">
     <label for="review-toggle">Review Mode</label>

--- a/popup.js
+++ b/popup.js
@@ -1,18 +1,20 @@
-// Handles enable/disable toggle, light mode and review mode
+// Handles enable/disable toggle and theme selections
 const toggle = document.getElementById("extension-toggle");
 const lightToggle = document.getElementById("light-toggle");
+const bentoToggle = document.getElementById("bento-toggle");
 const reviewToggle = document.getElementById("review-toggle");
 
 function loadState() {
-  chrome.storage.local.get({ extensionEnabled: true, lightMode: false, fennecReviewMode: false }, ({ extensionEnabled, lightMode, fennecReviewMode }) => {
+  chrome.storage.local.get({ extensionEnabled: true, lightMode: false, bentoMode: false, fennecReviewMode: false }, ({ extensionEnabled, lightMode, bentoMode, fennecReviewMode }) => {
     toggle.checked = Boolean(extensionEnabled);
     lightToggle.checked = Boolean(lightMode);
+    bentoToggle.checked = Boolean(bentoMode);
     reviewToggle.checked = Boolean(fennecReviewMode);
   });
 }
 
 function saveState() {
-  chrome.storage.local.set({ extensionEnabled: toggle.checked, lightMode: lightToggle.checked, fennecReviewMode: reviewToggle.checked }, () => {
+  chrome.storage.local.set({ extensionEnabled: toggle.checked, lightMode: lightToggle.checked, bentoMode: bentoToggle.checked, fennecReviewMode: reviewToggle.checked }, () => {
     const urls = [
       'https://mail.google.com/*',
       'https://*.incfile.com/incfile/order/detail/*',
@@ -40,5 +42,6 @@ document.addEventListener('DOMContentLoaded', () => {
   loadState();
   toggle.addEventListener("change", saveState);
   lightToggle.addEventListener("change", saveState);
+  bentoToggle.addEventListener("change", saveState);
   reviewToggle.addEventListener("change", saveState);
 });

--- a/styles/sidebar_bento.css
+++ b/styles/sidebar_bento.css
@@ -1,0 +1,33 @@
+/* Bento grid inspired theme with soft pastel blocks */
+.fennec-bento-mode #copilot-sidebar {
+    background: #f8f8f8;
+    color: #222;
+}
+.fennec-bento-mode .copilot-header {
+    background: #ffe4b5;
+    color: #000;
+    border-bottom: 1px solid #ddd;
+}
+.fennec-bento-mode .copilot-button {
+    background-color: #ffd1dc;
+    color: #000;
+    border: 1px solid #ccc;
+}
+.fennec-bento-mode .copilot-body {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+}
+.fennec-bento-mode .copilot-body > * {
+    grid-column: span 2;
+}
+.fennec-bento-mode .order-summary-box,
+.fennec-bento-mode .intel-summary-box,
+.fennec-bento-mode .issue-summary-box,
+.fennec-bento-mode #copilot-sidebar .white-box {
+    background: #fff;
+    border: 1px solid #ddd;
+    color: #222;
+    border-radius: 8px;
+    padding: 8px;
+}


### PR DESCRIPTION
## Summary
- add new Bento Mode theme CSS
- include Bento Mode toggle in popup
- store new setting in storage and apply class in Gmail and DB launchers
- document Bento Mode in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855c4a510f48326b28ef47b9f7bf67a