### PR TITLE
Add options page for configurable sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ information scraped from the current page.
    be available when visiting supported pages.
 5. Use the extension popup to enable **Light Mode** for a minimalist black and white style. Summary text is solid black with medium gray borders, the header shows white text on a black bar and the Fennec icon appears inverted.
 6. Enable **Bento Mode** from the popup to arrange the sidebar content in a colorful grid layout.
+7. Open the extension **Options** from the menu or the Extensions page to set a default sidebar width and Review Mode.
 
 ## Sidebar features
 
@@ -79,7 +80,7 @@ information scraped from the current page.
 - Hides the agent subscription status line when RA service is not provided by Incfile.
 - Provides a Quick Actions menu with **Emails** and **Cancel** options. **Emails** now opens a Gmail search for the order number, client email and name while **Cancel** resolves active issues and opens the cancellation dialog with the reason preselected.
 - The Quick Actions icon now appears at the start of the header like in Gmail and the menu fades in and out.
-- Review Mode is controlled only from the extension popup.
+- Review Mode can be toggled from the popup or configured as a default in the Options page.
 - A **REFRESH** button at the end of the summary reloads the data.
  - Closing the sidebar leaves a floating Fennec icon in the upper right corner to reopen it. Reopening refreshes the sidebar with the current order.
 - Cancel automation now detects the "Cancel / Refund" link even when spaces surround the slash.

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -545,7 +545,8 @@
         }
     }
 
-    chrome.storage.local.get({ extensionEnabled: true, lightMode: false, bentoMode: false, fennecReviewMode: false }, ({ extensionEnabled, lightMode, bentoMode, fennecReviewMode }) => {
+    chrome.storage.sync.get({ fennecReviewMode: false, sidebarWidth: 340 }, ({ fennecReviewMode, sidebarWidth }) => {
+        chrome.storage.local.get({ extensionEnabled: true, lightMode: false, bentoMode: false }, ({ extensionEnabled, lightMode, bentoMode }) => {
         if (!extensionEnabled) {
             console.log('[FENNEC] Extension disabled, skipping DB launcher.');
             return;
@@ -568,7 +569,7 @@
             if (!document.getElementById('copilot-sidebar')) {
                 console.log("[Copilot] Sidebar no encontrado, inyectando en DB...");
 
-                const SIDEBAR_WIDTH = 340;
+                const SIDEBAR_WIDTH = parseInt(sidebarWidth, 10) || 340;
                 document.body.style.transition = 'margin-right 0.2s';
                 document.body.style.marginRight = SIDEBAR_WIDTH + 'px';
 
@@ -1952,7 +1953,7 @@
 }
 
 chrome.storage.onChanged.addListener((changes, area) => {
-    if (area === 'local' && changes.fennecReviewMode) {
+    if (area === 'sync' && changes.fennecReviewMode) {
         reviewMode = changes.fennecReviewMode.newValue;
         updateReviewDisplay();
     }

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -10,7 +10,8 @@
             window.location.reload();
         }
     });
-    chrome.storage.local.get({ extensionEnabled: true, lightMode: false, bentoMode: false, fennecReviewMode: false }, ({ extensionEnabled, lightMode, bentoMode, fennecReviewMode }) => {
+    chrome.storage.sync.get({ fennecReviewMode: false, sidebarWidth: 340 }, ({ fennecReviewMode, sidebarWidth }) => {
+        chrome.storage.local.get({ extensionEnabled: true, lightMode: false, bentoMode: false }, ({ extensionEnabled, lightMode, bentoMode }) => {
         if (!extensionEnabled) {
             console.log('[FENNEC] Extension disabled, skipping Gmail launcher.');
             return;
@@ -26,7 +27,7 @@
             document.body.classList.remove('fennec-bento-mode');
         }
         try {
-            const SIDEBAR_WIDTH = 340;
+            const SIDEBAR_WIDTH = parseInt(sidebarWidth, 10) || 340;
             let reviewMode = sessionStorage.getItem('fennecReviewMode');
             reviewMode = reviewMode === null ? fennecReviewMode : reviewMode === 'true';
 
@@ -146,7 +147,7 @@
                 dnaBtn.remove();
                 refreshSidebar();
             }
-            chrome.storage.local.set({ fennecReviewMode: reviewMode });
+            chrome.storage.sync.set({ fennecReviewMode: reviewMode });
             updateDetailVisibility();
         }
 
@@ -768,7 +769,7 @@
             if (area === 'local' && changes.sidebarDb && document.getElementById('db-summary-section')) {
                 loadDbSummary();
             }
-            if (area === 'local' && changes.fennecReviewMode) {
+            if (area === 'sync' && changes.fennecReviewMode) {
                 reviewMode = changes.fennecReviewMode.newValue;
                 sessionStorage.setItem("fennecReviewMode", reviewMode ? "true" : "false");
                 applyReviewMode();
@@ -869,5 +870,6 @@
     } catch (e) {
         console.error("[Copilot] ERROR en Gmail Launcher:", e);
     }
+    });
     });
 })();

--- a/manifest.json
+++ b/manifest.json
@@ -137,6 +137,7 @@
       "128": "fennec_icon.png"
     }
   },
+  "options_page": "options.html",
   "background": {
     "service_worker": "core/background_emailsearch.js",
     "type": "module"

--- a/options.html
+++ b/options.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: Arial, sans-serif; width: 250px; padding: 10px; }
+        label { display: block; margin-top: 8px; }
+    </style>
+</head>
+<body>
+    <h2>FENNEC Options</h2>
+    <label>
+        <input type="checkbox" id="default-review"> Default Review Mode
+    </label>
+    <label>
+        Sidebar width (px)
+        <input type="number" id="sidebar-width" min="200" max="500" step="10">
+    </label>
+    <button id="save-btn" style="margin-top:10px;">Save</button>
+    <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,22 @@
+// Loads and stores sidebar options using chrome.storage.sync
+
+document.addEventListener("DOMContentLoaded", () => {
+    const reviewBox = document.getElementById("default-review");
+    const widthInput = document.getElementById("sidebar-width");
+    const saveBtn = document.getElementById("save-btn");
+
+    chrome.storage.sync.get({ defaultReviewMode: false, sidebarWidth: 340 }, (opts) => {
+        reviewBox.checked = Boolean(opts.defaultReviewMode);
+        widthInput.value = parseInt(opts.sidebarWidth, 10) || 340;
+    });
+
+    function save() {
+        const width = parseInt(widthInput.value, 10) || 340;
+        chrome.storage.sync.set({
+            defaultReviewMode: reviewBox.checked,
+            sidebarWidth: width
+        });
+    }
+
+    saveBtn.addEventListener("click", save);
+});


### PR DESCRIPTION
## Summary
- add `options.html` and `options.js` to configure default Review Mode and sidebar width
- declare new options page in the manifest
- load these settings from `chrome.storage.sync` in Gmail and DB launchers
- document the options page in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855ca1e84bc8326bfd8b3d9e9831ab3