### PR TITLE
Adjust order summary layout in Gmail

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ information scraped from the current page.
 - Officer and Shareholder sections are omitted for LLC orders.
 - Review Mode centers the order info with a clickable link to the order, removes the duplicate RA/VA tags from the Quick Summary and adds a new **CLIENT** box with the client ID, email, order count and LTV. This box is hidden unless Review Mode is active.
 - The ORDER SUMMARY in Review Mode now displays the order type and whether it is **Expedited**, shows the company name and ID beneath the sender details and includes a **BILLING** section pulled from the DB page. The Client box lists any roles held within the company or a purple **NOT LISTED** tag.
+- The Gmail ORDER SUMMARY layout was adjusted. The order number now matches the company heading size, opens the DB page when clicked and includes a copy icon. The order type and Expedited label appear below, followed by the sender name and email.
 
 ## Known limitations
 

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -995,6 +995,10 @@
 
     function extractAndShowFormationData(isAmendment = false) {
         const dbSections = [];
+        const completionLi = Array.from(document.querySelectorAll('li')).find(li =>
+            li.querySelector('a') && getText(li.querySelector('a')).toLowerCase() === 'completion date'
+        );
+        const expedited = completionLi && /expedited/i.test(getText(completionLi.querySelector('span')) || '');
         function addEmptySection(label) {
             const section = `
             <div class="section-label">${label}</div>
@@ -1458,7 +1462,12 @@
         }
 
         const orderInfo = getBasicOrderInfo();
-        chrome.storage.local.set({ sidebarDb: dbSections, sidebarOrderId: orderInfo.orderId });
+        orderInfo.type = currentOrderTypeText || orderInfo.type;
+        orderInfo.expedited = expedited;
+        orderInfo.companyName = company && company.name ? company.name : '';
+        orderInfo.companyId = company && company.stateId ? company.stateId : '';
+        orderInfo.companyState = company && company.state ? company.state : '';
+        chrome.storage.local.set({ sidebarDb: dbSections, sidebarOrderId: orderInfo.orderId, sidebarOrderInfo: orderInfo });
 
         const body = document.getElementById('copilot-body-content');
         if (body) {

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -356,6 +356,14 @@
             return `<span class="copilot-copy-icon" data-copy="${esc}" title="Copy">⧉</span>`;
         }
 
+        // Renders copyable text as a clickable link
+        function renderCopyLink(text, url, id = '') {
+            if (!text) return '<span style="color:#aaa">-</span>';
+            const esc = escapeHtml(text);
+            const idAttr = id ? ` id="${id}"` : '';
+            return `<a href="#"${idAttr} class="copilot-copy" data-copy="${esc}" data-url="${escapeHtml(url)}">${esc}</a>`;
+        }
+
         function parseOrderDetails(text) {
             const details = {};
 
@@ -443,8 +451,11 @@
             const orderId = context?.orderNumber || (storedOrderInfo && storedOrderInfo.orderId) || '';
             const url = orderId ? `https://db.incfile.com/incfile/order/detail/${orderId}` : '#';
 
-            let html = `<div id="order-summary-link" data-url="${url}" style="text-align:center">`;
-            if (orderId) html += `<b>${renderCopy(orderId)} ${renderCopyIcon(orderId)}</b>`;
+            let html = `<div style="text-align:center">`;
+            if (orderId) {
+                const link = renderCopyLink(orderId, url, "order-summary-link");
+                html += `<div><b>${link} ${renderCopyIcon(orderId)}</b></div>`;
+            }
             if (reviewMode && storedOrderInfo) {
                 if (storedOrderInfo.type) html += `<div>${escapeHtml(storedOrderInfo.type)}</div>`;
                 if (storedOrderInfo.expedited) html += `<div><span class="copilot-tag">Expedited</span></div>`;


### PR DESCRIPTION
## Summary
- refine Gmail ORDER SUMMARY design with clickable order number
- track expedited status from DB pages
- expose order info with new sidebar storage field
- document new layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685627a434e483269b822169da32949e