### PR TITLE
Enhance Gmail order summary details

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ information scraped from the current page.
 - Officer and Shareholder sections are omitted for LLC orders.
 - Review Mode centers the order info with a clickable link to the order, removes the duplicate RA/VA tags from the Quick Summary and adds a new **CLIENT** box with the client ID, email, order count and LTV. This box is hidden unless Review Mode is active.
 - The ORDER SUMMARY in Review Mode now displays the order type and whether it is **Expedited**, shows the company name and ID beneath the sender details and includes a **BILLING** section pulled from the DB page. The Client box lists any roles held within the company or a purple **NOT LISTED** tag.
+- The Gmail ORDER SUMMARY shows the order number as a clickable link with a copy icon. The order type and an **Expedited** tag appear below it, followed by the sender name and email, which are combined when identical.
 
 ## Known limitations
 

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1458,7 +1458,19 @@
         }
 
         const orderInfo = getBasicOrderInfo();
-        chrome.storage.local.set({ sidebarDb: dbSections, sidebarOrderId: orderInfo.orderId });
+        const sidebarOrderInfo = {
+            orderId: orderInfo.orderId,
+            type: currentOrderTypeText || orderInfo.type,
+            expedited: isExpeditedOrder(),
+            companyName: company ? company.name : null,
+            companyId: company ? company.stateId : null,
+            companyState: company ? company.state : null
+        };
+        chrome.storage.local.set({
+            sidebarDb: dbSections,
+            sidebarOrderId: orderInfo.orderId,
+            sidebarOrderInfo
+        });
 
         const body = document.getElementById('copilot-body-content');
         if (body) {
@@ -1596,6 +1608,17 @@
         const date = formatDateLikeParent(dateRaw);
         const status = getText(document.querySelector('.btn-status-text')) || '';
         return { orderId, type, date, status };
+    }
+
+    function isExpeditedOrder() {
+        const li = Array.from(document.querySelectorAll('li')).find(li => {
+            const icon = li.querySelector('i.mdi.mdi-truck');
+            const link = li.querySelector('a');
+            return icon && link && /completion date/i.test(getText(link));
+        });
+        if (!li) return false;
+        const span = li.querySelector('span.pull-right');
+        return span && /expedited/i.test(getText(span));
     }
 
     function getParentOrderId() {

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -443,8 +443,8 @@
             const orderId = context?.orderNumber || (storedOrderInfo && storedOrderInfo.orderId) || '';
             const url = orderId ? `https://db.incfile.com/incfile/order/detail/${orderId}` : '#';
 
-            let html = `<div id="order-summary-link" data-url="${url}" style="text-align:center">`;
-            if (orderId) html += `<b>${renderCopy(orderId)} ${renderCopyIcon(orderId)}</b>`;
+            let html = `<div id="order-summary-link" style="text-align:center">`;
+            if (orderId) html += `<b><a href="#" id="order-link">${renderCopy(orderId)}</a> ${renderCopyIcon(orderId)}</b>`;
             if (reviewMode && storedOrderInfo) {
                 if (storedOrderInfo.type) html += `<div>${escapeHtml(storedOrderInfo.type)}</div>`;
                 if (storedOrderInfo.expedited) html += `<div><span class="copilot-tag">Expedited</span></div>`;
@@ -462,7 +462,7 @@
             }
             html += '</div>';
             summaryBox.innerHTML = html;
-            const link = summaryBox.querySelector('#order-summary-link');
+            const link = summaryBox.querySelector('#order-link');
             if (link && orderId) {
                 link.addEventListener('click', (e) => {
                     e.preventDefault();


### PR DESCRIPTION
## Summary
- store additional order info from DB including expedited flag
- show order number in Gmail as a clickable link with copy icon
- display order type and expedited tag above sender info
- document updated ORDER SUMMARY behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856299713b8832695b020ef4aac4294