### PR TITLE
Fix Review Mode RA handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ information scraped from the current page.
 - A separator line now appears between addresses and the RA/VA tags in the quick summary, and those tags are repeated at the bottom of the Company section. Fields showing `N/A` or blank values are omitted, and shareholders display their share count prefixed with "Shares:".
 - Sections lacking meaningful details now show **NO INFO** instead of being hidden.
 - The AGENT section now displays **NO RA INFO** when Registered Agent details are missing.
+- When RA details are missing, the Company section shows a **NO RA INFO** tag after the RA/VA labels so Review Mode doesn't leave an empty space.
 - Officer and Shareholder sections are omitted for LLC orders.
 - Review Mode centers the order info with a clickable link to the order, removes the duplicate RA/VA tags from the Quick Summary and adds a new **CLIENT** box with the client ID, email, order count and LTV. This box is hidden unless Review Mode is active.
 - The ORDER SUMMARY in Review Mode now displays the order type and whether it is **Expedited**, shows the company name and ID beneath the sender details and includes a **BILLING** section pulled from the DB page. The Client box lists any roles held within the company or a purple **NOT LISTED** tag.

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1080,6 +1080,7 @@
             expiration: agentRaw.expiration,
             address: buildAddress(agentRaw)
         } : {};
+        const hasAgentInfo = agent && Object.values(agent).some(v => isValidField(v));
 
 
 
@@ -1347,7 +1348,10 @@
             companyLines.push(`<div>${renderKb(company.state)}</div>`);
             companyLines.push(addrHtml);
             companyLines.push(`<div class="company-purpose">${renderCopy(company.purpose)}</div>`);
-            companyLines.push(`<div><span class="${raClass}">RA: ${hasRA ? 'Sí' : 'No'}</span> <span class="${vaClass}">VA: ${hasVA ? 'Sí' : 'No'}</span></div>`);
+            companyLines.push(
+                `<div><span class="${raClass}">RA: ${hasRA ? 'Sí' : 'No'}</span> ` +
+                `<span class="${vaClass}">VA: ${hasVA ? 'Sí' : 'No'}</span>${hasAgentInfo ? '' : ' <span class="copilot-tag">NO RA INFO</span>'}</div>`
+            );
             const compSection = `
             <div class="section-label">COMPANY:</div>
             <div class="white-box" style="margin-bottom:10px">
@@ -1363,7 +1367,6 @@
             addEmptySection('COMPANY:');
         }
         // AGENT
-        const hasAgentInfo = agent && Object.values(agent).some(v => isValidField(v));
         if (hasAgentInfo) {
             const expDate = agent.expiration ? parseDate(agent.expiration) : null;
             const expired = expDate && expDate < new Date();

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -113,12 +113,11 @@
                 const compLabel = Array.from(container.querySelectorAll(".section-label"))
                     .find(l => l.textContent.trim().startsWith("COMPANY"));
                 const compBox = compLabel ? compLabel.nextElementSibling : null;
-                if (compLabel && compBox) {
-                    compLabel.dataset.reviewMerged = "1";
+                if (compBox) {
                     compBox.dataset.reviewMerged = "1";
-                    orderBox.appendChild(compLabel);
                     orderBox.appendChild(compBox);
                 }
+                if (compLabel) compLabel.style.display = "none";
                 orderBox.insertAdjacentElement("afterend", quick);
                 quick.classList.remove("quick-summary-collapsed");
                 quick.style.maxHeight = quick.scrollHeight + "px";


### PR DESCRIPTION
## Summary
- show NO RA INFO inside the COMPANY section when agent data is missing
- hide the `COMPANY:` label in Gmail Review Mode
- document new RA label behavior in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856354bfde083268e2d2a029951133d