### PR TITLE
Improve parent order detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,4 +257,6 @@ Reload the extension after editing the manifest.
 - Common helpers moved to `core/utils.js` and shared by Gmail and DB scripts.
 - Improved parent order detection in the Family Tree view so miscellaneous
   orders load correctly.
+- Further improved detection when the parent order link sits inside the
+  company tab on SB non-formation orders.
 

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1666,6 +1666,11 @@
         if (label) {
             const area = label.closest('.form-group') || label.closest('tr') || label.parentElement;
             if (area) {
+                const anchor = area.querySelector('a[href*="/order/detail/"]');
+                if (anchor) {
+                    const m = anchor.href.match(/detail\/(\d+)/);
+                    if (m) return m[1];
+                }
                 const digits = area.textContent.replace(/\D/g, '');
                 if (digits) return digits;
             }


### PR DESCRIPTION
## Summary
- grab the parent order ID from the link href before falling back to digits in text
- note the improved detection for SB non-formation orders in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685636a3dd148326b16b3717a7138410