### PR TITLE
Fix RA label in review mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ information scraped from the current page.
 - Gmail Review Mode removes the **COMPANY** heading in the order summary and
   trims blank agent fields. When no agent details are available the section shows
   **NO RA INFO**.
+- Fixed blank lines after the RA/VA labels in Gmail Review Mode when the agent
+  name was not detected. The AGENT section now shows **NO RA INFO**.
 
 ## Known limitations
 

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1155,7 +1155,7 @@
 
         const roleMap = {};
         const addRole = (name, role, addr) => {
-            if (!name || isInternal(name, addr)) return;
+            if (!name || !isValidField(name) || isInternal(name, addr)) return;
             const key = name.trim().toLowerCase();
             if (!roleMap[key]) roleMap[key] = { display: name.trim(), roles: new Set() };
             roleMap[key].roles.add(role);
@@ -1260,13 +1260,15 @@
 
         const summaryParts = [];
         const roleEntries = Object.values(roleMap)
-            .map(r => `
-                <div style="margin-left:10px">
-                    <b>${renderCopy(r.display)}</b><br>
-                    ${Array.from(r.roles)
-                        .map(role => `<span class="copilot-tag">${escapeHtml(role)}</span>`)
-                        .join(' ')}
-                </div>`);
+            .map(r => {
+                const name = renderCopy(r.display);
+                if (!name) return null;
+                const tags = Array.from(r.roles)
+                    .map(role => `<span class="copilot-tag">${escapeHtml(role)}</span>`)
+                    .join(' ');
+                return `<div style="margin-left:10px"><b>${name}</b><br>${tags}</div>`;
+            })
+            .filter(Boolean);
         if (roleEntries.length) {
             summaryParts.push(...roleEntries);
         }


### PR DESCRIPTION
## Summary
- avoid adding RA role when the agent name isn't valid
- skip blank role entries so Gmail review mode doesn't show stray RA tag
- document the fix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68564d882ba48326b47f075ee8c90075