### PR TITLE
Update client info display

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ information scraped from the current page.
 - The AGENT section now displays **NO RA INFO** when Registered Agent details are missing.
 - Officer and Shareholder sections are omitted for LLC orders.
 - Review Mode centers the order info with a clickable link to the order, removes the duplicate RA/VA tags from the Quick Summary and adds a new **CLIENT** box with the client ID, email, order count and LTV. This box is hidden unless Review Mode is active.
-- The ORDER SUMMARY in Review Mode now displays the order type and whether it is **Expedited**, shows the company name and ID beneath the sender details and includes a **BILLING** section pulled from the DB page. The Client box lists any roles held within the company or a purple **NOT LISTED** tag.
+- The ORDER SUMMARY in Review Mode now displays the order type and whether it is **Expedited**, shows the company name and ID beneath the sender details and includes a **BILLING** section pulled from the DB page. The Client box lists any roles held within the company or a purple **NOT LISTED** tag. The Client ID now links to the DB client page, the email and phone are clickable and the orders line is labeled **Companies**.
 - The Gmail ORDER SUMMARY shows the order number as a clickable link with a copy icon. The order type and an **Expedited** tag appear below it, followed by the sender name and email, which are combined when identical.
 - The Gmail order link now uses white text that only underlines on hover, and the order type and expedited status appear side by side as labels.
 - The DB quick summary places RA/VA labels closer to the Registered Agent address.

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1288,10 +1288,30 @@
         const client = getClientInfo();
         if (client && (client.id || client.name || client.email)) {
             const lines = [];
-            if (client.id) lines.push(`<div><b>${renderCopy(client.id)}</b></div>`);
-            if (client.name) lines.push(`<div>${renderCopy(client.name)}</div>`);
-            if (client.email) lines.push(`<div>${renderCopy(client.email)}</div>`);
-            if (client.orders) lines.push(`<div>Orders: ${renderCopy(client.orders)}</div>`);
+            if (client.id) {
+                const url = `${location.origin}/incfile/order/users/get-user/${client.id}?ownerID=${client.id}`;
+                lines.push(`<div><b><a href="${url}" target="_blank">${escapeHtml(client.id)}</a></b></div>`);
+            }
+            if (client.name) {
+                lines.push(`<div>${renderCopy(client.name)}</div>`);
+                const r = roleMap[client.name.trim().toLowerCase()];
+                if (r && r.roles && r.roles.size) {
+                    const tags = Array.from(r.roles)
+                        .map(role => `<span class="copilot-tag">${escapeHtml(role)}</span>`)
+                        .join(' ');
+                    lines.push(`<div>${tags}</div>`);
+                } else {
+                    lines.push(`<div><span class="copilot-tag copilot-tag-purple">NOT LISTED</span></div>`);
+                }
+            }
+            if (client.email) {
+                lines.push(`<div><a href="mailto:${encodeURIComponent(client.email)}">${escapeHtml(client.email)}</a></div>`);
+            }
+            if (client.phone) {
+                const digits = client.phone.replace(/[^\d]/g, '');
+                lines.push(`<div><a href="tel:${digits}">${escapeHtml(client.phone)}</a></div>`);
+            }
+            if (client.orders) lines.push(`<div>Companies: ${renderCopy(client.orders)}</div>`);
             if (client.ltv) lines.push(`<div>LTV: ${renderCopy(client.ltv)}</div>`);
             const clientSection = `
             <div id="client-section-label" class="section-label">CLIENT:</div>
@@ -1705,11 +1725,15 @@
                 const contactCell = row.querySelector('td[id^="clientContact"]');
                 const name = nameCell ? getText(nameCell).replace(/^\s*✓?\s*/, '') : '';
                 let email = '';
+                let phone = '';
                 if (contactCell) {
-                    const match = getText(contactCell).match(/[\w.+-]+@[\w.-]+/);
-                    if (match) email = match[0];
+                    const text = getText(contactCell);
+                    const em = text.match(/[\w.+-]+@[\w.-]+/);
+                    const ph = text.match(/\(?\d{3}\)?[-\s]?\d{3}[-\s]?\d{4}/);
+                    if (em) email = em[0];
+                    if (ph) phone = ph[0];
                 }
-                return { id, orders, ltv, name, email };
+                return { id, orders, ltv, name, email, phone };
             }
         }
         const contactHeader = Array.from(document.querySelectorAll('h3.box-title'))
@@ -1723,10 +1747,13 @@
                     .find(l => getText(l).toLowerCase().startsWith('email'));
                 const name = nameLabel ? getText(nameLabel.parentElement.querySelector('.form-control-static')) : '';
                 const email = emailLabel ? getText(emailLabel.parentElement.querySelector('.form-control-static')) : '';
-                return { id: '', orders: '', ltv: '', name, email };
+                const phoneLabel = Array.from(body.querySelectorAll('label'))
+                    .find(l => getText(l).toLowerCase().startsWith('phone'));
+                const phone = phoneLabel ? getText(phoneLabel.parentElement.querySelector('.form-control-static')) : '';
+                return { id: '', orders: '', ltv: '', name, email, phone };
             }
         }
-        return { id: '', orders: '', ltv: '', name: '', email: '' };
+        return { id: '', orders: '', ltv: '', name: '', email: '', phone: '' };
     }
 
     function diagnoseHoldOrders(orders) {


### PR DESCRIPTION
## Summary
- show links for client ID, email and phone
- display client roles or NOT LISTED label
- rename Orders to Companies in client box
- document updated client info

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685650f08ec08326983f1f75a05216e9