### PR TITLE
Fix parent order detection in DB pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,4 +269,5 @@ Reload the extension after editing the manifest.
   billing details.
 - Fixed parent order detection when multiple sections contain "Parent Order" so
   the Family Tree icon works on SB pages.
+- Fixed detection when the Parent Order information only appears in the `#vcompany` tab.
 

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1762,6 +1762,17 @@
                 if (digits) return digits;
             }
         }
+
+        const compTab = document.querySelector('#vcomp, #vcompany');
+        if (compTab && /parent order/i.test(compTab.textContent)) {
+            const anchor = compTab.querySelector('a[href*="/order/detail/"]');
+            if (anchor) {
+                const m = anchor.href.match(/detail\/(\d+)/);
+                if (m) return m[1];
+            }
+            const digits = compTab.textContent.replace(/\D/g, '');
+            if (digits) return digits;
+        }
         return null;
     }
 


### PR DESCRIPTION
## Summary
- improve detection of parent order when the info appears in `#vcompany`
- document the fix in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68565a03b1f08326b2bfa070e98395f5