### PR TITLE
Fix parent order line detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,4 +270,6 @@ Reload the extension after editing the manifest.
 - Fixed parent order detection when multiple sections contain "Parent Order" so
   the Family Tree icon works on SB pages.
 - Fixed detection when the Parent Order information only appears in the `#vcompany` tab.
+- Fixed detection when the Parent Order line sits within a paragraph or list item
+  inside the `#vcomp` tab.
 

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1748,7 +1748,7 @@
             if (m) return m[1];
         }
 
-        const labels = Array.from(document.querySelectorAll('label,td,th,span,strong,b,div'))
+        const labels = Array.from(document.querySelectorAll('label,td,th,span,strong,b,div,p,li'))
             .filter(el => /parent order/i.test(getText(el)));
         for (const label of labels) {
             const area = label.closest('.form-group') || label.closest('tr') || label.parentElement;


### PR DESCRIPTION
## Summary
- pick up Parent Order in paragraphs or list items so Family Tree opens
- document Parent Order line detection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68565bf6b1588326a780cb25bd1e09a6