### PR TITLE
Fix parent order lookup in family tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,4 +280,6 @@ Reload the extension after editing the manifest.
 - Fixed detection when the Parent Order link only shows digits inside the
   `#vcomp` tab so the Family Tree icon opens correctly.
 - Simplified parent order lookup to only search within the `#vcomp` tab.
+- Fixed missing parent order on SB miscellaneous orders when the label is not
+  inside a `.form-group` container.
 

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1718,22 +1718,19 @@
     }
 
     function getParentOrderId() {
-        const compTab = document.querySelector('#vcomp');
-        if (!compTab) return null;
-        const group = Array.from(compTab.querySelectorAll('.col-md-12 .form-group'))
-            .find(g => {
-                const lbl = g.querySelector('label');
-                return lbl && /parent order/i.test(getText(lbl));
-            });
-        if (!group) return null;
-        const anchor = group.querySelector('a[href*="/order/detail/"]');
+        const tab = document.querySelector('#vcomp') || document.querySelector('#vcompany');
+        if (!tab) return null;
+        const parentEl = Array.from(tab.querySelectorAll('label, div, p, li, span, td, strong'))
+            .find(el => /parent order/i.test(getText(el)));
+        if (!parentEl) return null;
+        const anchor = parentEl.querySelector('a[href*="/order/detail/"]');
         if (anchor) {
             const m = anchor.href.match(/detail\/(\d+)/);
             if (m) return m[1];
             const textId = anchor.textContent.replace(/\D/g, '');
             if (textId) return textId;
         }
-        const digits = group.textContent.replace(/\D/g, '');
+        const digits = parentEl.textContent.replace(/\D/g, '');
         return digits || null;
     }
 


### PR DESCRIPTION
## Summary
- broaden parent order search to handle SB MISC cases
- document the fix in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685667fc8b848326bf2578f9055902d9