### PR TITLE
Improve logging for parent order detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,4 +282,6 @@ Reload the extension after editing the manifest.
 - Simplified parent order lookup to only search within the `#vcomp` tab.
 - Fixed missing parent order on SB miscellaneous orders when the label is not
   inside a `.form-group` container.
+- Added console logs to help trace parent order detection when the Family Tree
+  icon is clicked.
 

--- a/core/utils.js
+++ b/core/utils.js
@@ -74,6 +74,7 @@ function attachCommonListeners(rootEl) {
     const ftIcon = document.getElementById('family-tree-icon');
     if (ftIcon) {
         ftIcon.addEventListener('click', () => {
+            console.log('[Copilot] Family Tree icon clicked');
             let container = document.getElementById('family-tree-orders');
             if (!container) {
                 const qs = document.getElementById('quick-summary');
@@ -99,7 +100,9 @@ function attachCommonListeners(rootEl) {
                 return;
             }
             const parentId = typeof getParentOrderId === 'function' ? getParentOrderId() : null;
+            console.log('[Copilot] Detected parent order ID:', parentId);
             if (!parentId) {
+                console.warn('[Copilot] Parent order not found');
                 alert('Parent order not found');
                 return;
             }

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1718,19 +1718,37 @@
     }
 
     function getParentOrderId() {
+        console.log("[Copilot] Scanning for parent order in #vcomp");
         const tab = document.querySelector('#vcomp') || document.querySelector('#vcompany');
-        if (!tab) return null;
+        if (!tab) {
+            console.log("[Copilot] #vcomp tab not found");
+            return null;
+        }
         const parentEl = Array.from(tab.querySelectorAll('label, div, p, li, span, td, strong'))
             .find(el => /parent order/i.test(getText(el)));
-        if (!parentEl) return null;
+        if (!parentEl) {
+            console.log("[Copilot] Parent order element not found");
+            return null;
+        }
+        console.log("[Copilot] Parent order element text:", getText(parentEl).trim());
         const anchor = parentEl.querySelector('a[href*="/order/detail/"]');
         if (anchor) {
+            console.log("[Copilot] Found parent order link", anchor.href);
             const m = anchor.href.match(/detail\/(\d+)/);
-            if (m) return m[1];
+            if (m) {
+                console.log("[Copilot] Extracted ID from href:", m[1]);
+                return m[1];
+            }
             const textId = anchor.textContent.replace(/\D/g, '');
-            if (textId) return textId;
+            if (textId) {
+                console.log("[Copilot] Extracted ID from link text:", textId);
+                return textId;
+            }
+            console.log("[Copilot] No numeric ID in parent link");
         }
         const digits = parentEl.textContent.replace(/\D/g, '');
+        if (digits) console.log("[Copilot] Extracted ID from text:", digits);
+        else console.log("[Copilot] No digits found in parent element text");
         return digits || null;
     }
 


### PR DESCRIPTION
## Summary
- add console debug output for Family Tree interactions
- document parent order debug logs in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685669647f4883269996fcb103a11d35