### PR TITLE
Improve parent order debug logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,4 +284,6 @@ Reload the extension after editing the manifest.
   inside a `.form-group` container.
 - Added console logs to help trace parent order detection when the Family Tree
   icon is clicked.
+- When the parent order isn't found, the console now prints the text from the
+  scanned sections to aid troubleshooting.
 

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1724,10 +1724,19 @@
             console.log("[Copilot] #vcomp tab not found");
             return null;
         }
-        const parentEl = Array.from(tab.querySelectorAll('label, div, p, li, span, td, strong'))
-            .find(el => /parent order/i.test(getText(el)));
+        const candidates = Array.from(tab.querySelectorAll('label, div, p, li, span, td, strong'));
+        const parentEl = candidates.find(el => /parent order/i.test(getText(el)));
         if (!parentEl) {
             console.log("[Copilot] Parent order element not found");
+            const scanned = candidates
+                .map(el => getText(el).trim())
+                .filter(Boolean)
+                .slice(0, 20);
+            if (scanned.length) {
+                console.log("[Copilot] Scanned sections:", scanned);
+            } else {
+                console.log("[Copilot] No text found in scanned sections");
+            }
             return null;
         }
         console.log("[Copilot] Parent order element text:", getText(parentEl).trim());


### PR DESCRIPTION
## Summary
- log the text of scanned sections when parent order is missing
- document new debug feature in README

## Testing
- `node manual-test.js`

------
https://chatgpt.com/codex/tasks/task_e_68566ad3a61c8326af685e4f54bea6c6