### PR TITLE
Improve parent order logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,4 +284,6 @@ Reload the extension after editing the manifest.
   inside a `.form-group` container.
 - Added console logs to help trace parent order detection when the Family Tree
   icon is clicked.
+- When the parent order cannot be detected the console lists all scanned
+  elements with their text for easier debugging.
 

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1724,10 +1724,16 @@
             console.log("[Copilot] #vcomp tab not found");
             return null;
         }
-        const parentEl = Array.from(tab.querySelectorAll('label, div, p, li, span, td, strong'))
-            .find(el => /parent order/i.test(getText(el)));
+        const candidates = Array.from(
+            tab.querySelectorAll("label, div, p, li, span, td, strong")
+        );
+        const parentEl = candidates.find(el => /parent order/i.test(getText(el)));
         if (!parentEl) {
-            console.log("[Copilot] Parent order element not found");
+            console.log("[Copilot] Parent order element not found; scanned:");
+            candidates.forEach(el => {
+                const txt = getText(el).trim();
+                if (txt) console.log("- " + el.tagName + ": " + txt);
+            });
             return null;
         }
         console.log("[Copilot] Parent order element text:", getText(parentEl).trim());


### PR DESCRIPTION
## Summary
- log which elements were scanned when parent order detection fails
- document new debug output in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68566ad3a61c8326af685e4f54bea6c6