### PR TITLE
Improve parent order debug logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ Reload the extension after editing the manifest.
   icon is clicked.
 - When the parent order cannot be detected the console lists all scanned
   elements with their text for easier debugging.
+- The console now prints the text of any sibling elements inspected for digits
+  when no parent ID is found.
 - Fixed detection when the parent order number appears in a sibling element
   next to the label inside the `#vcomp` tab.
 

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1755,10 +1755,10 @@
             }
             console.log("[Copilot] No numeric ID in parent link");
         }
-        let digits = parentEl.textContent.replace(/\D/g, '');
+        let digits = parentEl.textContent.replace(/\D/g, "");
         if (!digits) {
             let valEl = parentEl.nextElementSibling;
-            const container = parentEl.closest('div');
+            const container = parentEl.closest("div");
             if ((!valEl || !getText(valEl)) && container) {
                 if (container.nextElementSibling && getText(container.nextElementSibling)) {
                     valEl = container.nextElementSibling;
@@ -1773,10 +1773,16 @@
                     }
                 }
             }
-            if (valEl) digits = valEl.textContent.replace(/\D/g, '');
+            if (valEl) {
+                console.log("[Copilot] Checked sibling text:", getText(valEl).trim());
+                digits = valEl.textContent.replace(/\D/g, "");
+            }
         }
         if (digits) console.log("[Copilot] Extracted ID from text:", digits);
-        else console.log("[Copilot] No digits found in parent element text or siblings");
+        else {
+            console.log("[Copilot] No digits found in parent element text or siblings");
+            console.log("[Copilot] Parent text scanned:", getText(parentEl).trim());
+        }
         return digits || null;
     }
 


### PR DESCRIPTION
## Summary
- show sibling text scanned for parent order detection
- document new logging in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68566f08d61483269d9f9f4bdb59c86f