### PR TITLE
Fix Family Tree helper scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,4 +290,6 @@ Reload the extension after editing the manifest.
   when no parent ID is found.
 - Fixed detection when the parent order number appears in a sibling element
   next to the label inside the `#vcomp` tab.
+- Exposed the `getParentOrderId` and `diagnoseHoldOrders` helpers globally so the
+  Family Tree icon works consistently.
 

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1904,7 +1904,7 @@
         // legacy function kept for compatibility
     }
 
-    function getLastHoldUser() {
+function getLastHoldUser() {
         const trigger = document.querySelector("a[onclick*='modalTrackOrderHistory']");
         if (trigger) trigger.click();
         let attempts = 10;
@@ -1944,6 +1944,10 @@
         check();
     });
 }
+
+    // Expose helpers so core/utils.js can access them
+    window.getParentOrderId = getParentOrderId;
+    window.diagnoseHoldOrders = diagnoseHoldOrders;
 
 chrome.storage.onChanged.addListener((changes, area) => {
     if (area === 'local' && changes.fennecReviewMode) {


### PR DESCRIPTION
## Summary
- expose `getParentOrderId` and `diagnoseHoldOrders` on `window`
- note fix in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68567416899883268071c70f01b6964d