### PR TITLE
Implement sidebar reset on email search

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ information scraped from the current page.
 - The order number parser is tolerant to common formats (e.g. with `#`, parentheses or spaces).
 - Displays a small order summary only after you click **EMAIL SEARCH** or
   **OPEN ORDER**, so old details no longer appear automatically.
+- Clicking **EMAIL SEARCH** clears any previous order details and shows a
+  blinking white Fennec icon while the new data loads.
 - Opens Gmail search and the DB order page in new tabs when clicking the buttons.
 - Uses `margin-right` to ensure Gmail navigation controls stay visible.
 - The top header bar shifts left along with the main panels so account menus remain accessible.

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -608,6 +608,23 @@
             });
         }
 
+        function showLoadingState() {
+            currentContext = null;
+            storedOrderInfo = null;
+            const orderBox = document.getElementById('order-summary-content');
+            const dbBox = document.getElementById('db-summary-section');
+            const issueContent = document.getElementById('issue-summary-content');
+            const issueLabel = document.getElementById('issue-status-label');
+            const icon = `<img src="${chrome.runtime.getURL('fennec_icon.png')}" class="loading-fennec"/>`;
+            if (orderBox) orderBox.innerHTML = icon;
+            if (dbBox) dbBox.innerHTML = icon;
+            if (issueContent) issueContent.innerHTML = icon;
+            if (issueLabel) {
+                issueLabel.textContent = '';
+                issueLabel.className = 'issue-status-label';
+            }
+        }
+
         function refreshSidebar() {
             const ctx = extractOrderContextFromEmail();
             currentContext = ctx;
@@ -617,6 +634,8 @@
         }
 
         function handleEmailSearchClick() {
+            showLoadingState();
+
             const context = extractOrderContextFromEmail();
             currentContext = context;
             fillOrderSummaryBox(context);

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -412,6 +412,7 @@
     width: 20px;
     animation: fennec-blink 1s linear infinite;
     vertical-align: middle;
+    filter: brightness(0) invert(1);
 }
 .copilot-footer {
     margin-top: 10px;

--- a/styles/sidebar_light.css
+++ b/styles/sidebar_light.css
@@ -84,5 +84,5 @@
 .fennec-light-mode .copilot-icon,
 .fennec-light-mode #fennec-floating-icon,
 .fennec-light-mode .loading-fennec {
-    filter: invert(1);
+    filter: brightness(0) invert(1);
 }


### PR DESCRIPTION
## Summary
- reset previous sidebar data when clicking **EMAIL SEARCH**
- show flashing Fennec icon while order info loads
- make loading icon white in all themes
- document the new Gmail behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685733dc5ab4832683b3b3b7b975861a