### PR TITLE
Fix Review Mode client links

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ information scraped from the current page.
 - Sections lacking meaningful details now show **NO INFO** instead of being hidden.
 - The AGENT section now displays **NO RA INFO** when Registered Agent details are missing.
 - Officer and Shareholder sections are omitted for LLC orders.
-- Review Mode centers the order info with a clickable link to the order, removes the duplicate RA/VA tags from the Quick Summary and adds a new **CLIENT** box with the client ID, email, order count and LTV. This box is hidden unless Review Mode is active.
+- Review Mode centers the order info with a clickable link to the order, removes the duplicate RA/VA tags from the Quick Summary and adds a new **CLIENT** box with the client ID, email, phone, order count and LTV. The client ID now links directly to the company page and the company count and LTV share a single line. This box is hidden unless Review Mode is active.
 - The ORDER SUMMARY in Review Mode now displays the order type and whether it is **Expedited**, shows the company name and ID beneath the sender details and includes a **BILLING** section pulled from the DB page. The Client box lists any roles held within the company or a purple **NOT LISTED** tag.
 - In Gmail Review Mode a **BILLING** box appears below the Client section using data from the DB billing tab.
 - The Gmail ORDER SUMMARY shows the order number as a clickable link with a copy icon. The order type and an **Expedited** tag appear below it, followed by the sender name and email, which are combined when identical.

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1295,7 +1295,7 @@
         if (client && (client.id || client.name || client.email)) {
             const lines = [];
             if (client.id) {
-                const url = `${location.origin}/incfile/order/users/get-user/${client.id}?ownerID=${client.id}`;
+                const url = `${location.origin}/incfile/companies/${client.id}`;
                 lines.push(`<div><b><a href="${url}" target="_blank">${escapeHtml(client.id)}</a></b></div>`);
             }
             if (client.name) {
@@ -1317,8 +1317,10 @@
                 const digits = client.phone.replace(/[^\d]/g, '');
                 lines.push(`<div><a href="tel:${digits}">${escapeHtml(client.phone)}</a></div>`);
             }
-            if (client.orders) lines.push(`<div>Companies: ${renderCopy(client.orders)}</div>`);
-            if (client.ltv) lines.push(`<div>LTV: ${renderCopy(client.ltv)}</div>`);
+            const counts = [];
+            if (client.orders) counts.push(`Companies: ${renderCopy(client.orders)}`);
+            if (client.ltv) counts.push(`LTV: ${renderCopy(client.ltv)}`);
+            if (counts.length) lines.push(`<div>${counts.join(' \u2022 ')}</div>`);
             const clientSection = `
             <div id="client-section-label" class="section-label">CLIENT:</div>
             <div id="client-section-box" class="white-box" style="margin-bottom:10px">
@@ -1801,10 +1803,14 @@
                 let email = '';
                 let phone = '';
                 if (contactCell) {
+                    const mailEl = contactCell.querySelector('a[href^="mailto:"]');
+                    if (mailEl) email = getText(mailEl);
                     const text = getText(contactCell);
-                    const em = text.match(/[\w.+-]+@[\w.-]+/);
-                    const ph = text.match(/\(?\d{3}\)?[-\s]?\d{3}[-\s]?\d{4}/);
-                    if (em) email = em[0];
+                    if (!email) {
+                        const em = text.match(/[\w.+-]+@[\w.-]+/);
+                        if (em) email = em[0];
+                    }
+                    const ph = text.match(/\(?\d{3}\)?[-\s.]?\d{3}[-\s.]?\d{4}/);
                     if (ph) phone = ph[0];
                 }
                 return { id, orders, ltv, name, email, phone };


### PR DESCRIPTION
## Summary
- link the client ID in Review Mode to the DB company page
- keep email and phone parsed separately
- show Companies and LTV on a single line
- document new Review Mode behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857354dc314832686d917ac94b106ca