### PR TITLE
Improve Gmail order summary display

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ information scraped from the current page.
 - The Client box now lists the name first in bold, shows the client ID as a plain clickable link and combines the email and phone on a single line. The Billing box displays the cardholder first, then the card type, last four digits and expiration on one line and formats the address in two lines.
 - The Gmail ORDER SUMMARY in Review Mode now begins with the company name as a bold clickable link, shows the state ID on the next line when available, then lists the order number with type and **Expedited** labels. Sender name and email are omitted.
 - The Gmail order link now uses white text that only underlines on hover, and the order type and expedited status appear side by side as labels.
+- The Gmail ORDER SUMMARY now shows the company name in white at the same size as the title, adds a copy icon to the state ID line and removes duplicate name, ID and address lines when merging DB details.
 - The DB quick summary places RA/VA labels closer to the Registered Agent address.
 - Gmail Review Mode removes the **COMPANY** heading in the order summary and
   trims blank agent fields. When no agent details are available the section shows

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -181,6 +181,17 @@
                 const compBox = compLabel ? compLabel.nextElementSibling : null;
                 if (compBox) {
                     compBox.dataset.reviewMerged = "1";
+                    const purposeEl = compBox.querySelector('.company-purpose');
+                    if (purposeEl) {
+                        let prev = purposeEl.previousElementSibling;
+                        while (prev) {
+                            const toRemove = prev;
+                            prev = prev.previousElementSibling;
+                            toRemove.remove();
+                        }
+                    }
+                    const last = compBox.lastElementChild;
+                    if (last && !last.textContent.trim()) last.remove();
                     orderBox.appendChild(compBox);
                 }
                 if (compLabel) compLabel.remove();
@@ -514,13 +525,13 @@
                 const companyName = escapeHtml(storedOrderInfo.companyName || '');
                 if (companyName) {
                     const cLink = nameBase ? `<a href="#" id="company-link" class="copilot-sos copilot-link" data-url="${nameBase}" data-query="${companyName}" data-type="name">${companyName}</a>` : companyName;
-                    html += `<div><b>${cLink}</b></div>`;
+                    html += `<div class="order-summary-company"><b>${cLink}</b></div>`;
                 }
                 if (storedOrderInfo.companyId) {
                     const idBase = buildSosUrl(storedOrderInfo.companyState, null, 'id');
                     const compId = escapeHtml(storedOrderInfo.companyId);
                     const idLink = idBase ? `<a href="#" class="copilot-sos copilot-link" data-url="${idBase}" data-query="${compId}" data-type="id">${compId}</a>` : compId;
-                    html += `<div>${idLink}</div>`;
+                    html += `<div>${idLink} ${renderCopyIcon(storedOrderInfo.companyId)}</div>`;
                 }
             }
             if (orderId) html += `<div><b><a href="#" id="order-link" class="order-link">${renderCopy(orderId)}</a> ${renderCopyIcon(orderId)}</b></div>`;

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -253,6 +253,11 @@
     margin: 10px 0;
 }
 
+#copilot-sidebar .order-summary-company {
+    color: #fff;
+    font-size: 16px;
+}
+
 #copilot-sidebar .quick-summary-toggle {
     cursor: pointer;
     margin-left: 6px;


### PR DESCRIPTION
## Summary
- style company name line in ORDER SUMMARY
- add copy icon to State ID
- trim duplicate lines when merging DB company details
- document changes in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68574084b998832688773e7712db1083