### PR TITLE
Improve review mode display

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ information scraped from the current page.
   **NO RA INFO**.
 - Fixed blank lines after the RA/VA labels in Gmail Review Mode when the agent
   name was not detected. The AGENT section now shows **NO RA INFO**.
+- Gmail Review Mode hides the **ORDER SUMMARY** heading and reduces the space
+  before the Quick Summary.
+- Names in the Quick Summary now include **CLIENT** and **BILLING** tags when
+  they appear in those sections.
 
 ## Known limitations
 

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1225,6 +1225,11 @@
             });
         }
 
+        const client = getClientInfo();
+        if (client && client.name) addRole(client.name, 'CLIENT');
+        const billing = getBillingInfo();
+        if (billing && billing.cardholder) addRole(billing.cardholder, 'BILLING');
+
         const addrs = [];
         const pushAddr = (label, addr, name) => {
             if (!isValidField(addr) || isInternal(name, addr)) return;
@@ -1330,7 +1335,6 @@
         html += quickSection;
         dbSections.push(quickSection);
 
-        const client = getClientInfo();
         if (client && (client.id || client.name || client.email)) {
             const lines = [];
             if (client.name) {
@@ -1367,7 +1371,6 @@
             dbSections.push(clientSection);
         }
 
-        const billing = getBillingInfo();
         if (billing) {
             const linesB = [];
             if (billing.cardholder) {

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -215,6 +215,10 @@
         }
 
         function applyReviewMode() {
+            const header = document.querySelector("#copilot-sidebar .order-summary-header");
+            if (header) header.style.display = reviewMode ? "none" : "";
+            const orderBoxEl = document.querySelector("#copilot-sidebar .order-summary-box");
+            if (orderBoxEl) orderBoxEl.style.marginTop = reviewMode ? "4px" : "12px";
             const dnaRow = document.querySelector("#copilot-sidebar .copilot-dna");
             const dnaBtn = document.getElementById("btn-dna");
             if (reviewMode) {


### PR DESCRIPTION
## Summary
- hide ORDER SUMMARY heading in Gmail review mode
- trim gap before quick summary in Gmail
- tag client and billing names in DB quick summary
- document new review mode behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857430d71f48326b80eea1d6d5a8021