### PR TITLE
Improve sidebar layout and client info

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ information scraped from the current page.
   before the Quick Summary.
 - Names in the Quick Summary now include **CLIENT** and **BILLING** tags when
   they appear in those sections.
+- The Gmail sidebar displays a separator below the **DNA** button, the RA/VA labels
+  are followed by a separator line, address labels in the Quick Summary appear on
+  the next line, and the client email no longer merges with the phone number.
 
 ## Known limitations
 

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1300,9 +1300,8 @@
         const addrValues = Object.values(addrMap);
         const addrEntries = addrValues
             .map(a => {
-                const br = a.labels.includes('Agent') ? '' : '<br>';
                 const tags = a.labels.map(l => `<span class="copilot-tag">${escapeHtml(l)}</span>`).join(' ');
-                return `<div style="margin-left:10px"><b>${renderAddress(a.addr, isVAAddress(a.addr))}</b>${br}${tags}</div>`;
+                return `<div style="margin-left:10px"><b>${renderAddress(a.addr, isVAAddress(a.addr))}</b><br>${tags}</div>`;
             });
 
         // Render del HTML
@@ -1353,10 +1352,12 @@
                 const url = `${location.origin}/incfile/companies/${client.id}`;
                 lines.push(`<div><a href="${url}" class="copilot-link" target="_blank">${escapeHtml(client.id)}</a></div>`);
             }
-            if (client.email || client.phone) {
-                const emailHtml = client.email ? `<a href="mailto:${encodeURIComponent(client.email)}" class="copilot-link">${escapeHtml(client.email)}</a>` : '';
-                const phoneText = client.phone ? ` ${escapeHtml(client.phone)}` : '';
-                lines.push(`<div>${emailHtml}${phoneText}</div>`);
+            if (client.email) {
+                const emailHtml = `<a href="mailto:${encodeURIComponent(client.email)}" class="copilot-link">${escapeHtml(client.email)}</a>`;
+                lines.push(`<div>${emailHtml}</div>`);
+            }
+            if (client.phone) {
+                lines.push(`<div>${escapeHtml(client.phone)}</div>`);
             }
             const counts = [];
             if (client.orders) counts.push(`Companies: ${renderCopy(client.orders)}`);
@@ -1442,6 +1443,7 @@
                 `<div><span class="${raClass}">RA: ${hasRA ? 'Sí' : 'No'}</span> ` +
                 `<span class="${vaClass}">VA: ${hasVA ? 'Sí' : 'No'}</span></div>`
             );
+            companyLines.push('<hr style="border:none; border-top:1px solid #eee; margin:6px 0"/>');
             const compSection = reviewMode
                 ? `
             <div class="white-box" style="margin-bottom:10px">

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -779,6 +779,7 @@
                         <button id="btn-open-order" class="copilot-button">📂 OPEN ORDER</button>
                     </div>
                     <div class="copilot-dna"></div>
+                    <hr style="border:none;border-top:1px solid #eee;margin:6px 0"/>
                     <div class="order-summary-header">ORDER SUMMARY</div>
                     <div class="order-summary-box">
                         <div id="order-summary-content" style="color:#ccc; font-size:13px;">


### PR DESCRIPTION
## Summary
- add separator below DNA button in Gmail sidebar
- place RA/VA labels on their own line and separate from following section
- clean up client email display
- always put address labels on the next line
- document layout tweaks in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68574630155c832699fcd34994cef64f