### PR TITLE
Fix spacing for Gmail Review Mode quick summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ information scraped from the current page.
   **NO RA INFO**.
 - Fixed blank lines after the RA/VA labels in Gmail Review Mode when the agent
   name was not detected. The AGENT section now shows **NO RA INFO**.
-- Gmail Review Mode hides the **ORDER SUMMARY** heading and reduces the space
-  before the Quick Summary.
+- Gmail Review Mode hides the **ORDER SUMMARY** heading and now merges the
+  Quick Summary directly below it inside the same box to avoid extra spacing.
 - Names in the Quick Summary now include **CLIENT** and **BILLING** tags when
   they appear in those sections.
 - The Gmail sidebar displays a separator below the **DNA** button, the RA/VA labels

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -195,9 +195,12 @@
                     orderBox.appendChild(compBox);
                 }
                 if (compLabel) compLabel.remove();
-                orderBox.insertAdjacentElement("afterend", quick);
+                orderBox.appendChild(quick);
+                quick.classList.remove("white-box");
                 quick.classList.remove("quick-summary-collapsed");
-                quick.style.maxHeight = quick.scrollHeight + "px";
+                quick.style.margin = "8px 0 0";
+                quick.style.padding = "0";
+                quick.style.maxHeight = "none";
                 Array.from(container.children).forEach(el => {
                     if (el !== quick && el !== clientLabel && el !== clientBox && el !== billingLabel && el !== billingBox) el.style.display = "none";
                 });
@@ -208,6 +211,11 @@
                 if (issueBox) issueBox.style.display = "";
                 orderBox.querySelectorAll('[data-review-merged="1"]').forEach(el => el.remove());
                 if (quick.parentElement !== container) container.prepend(quick);
+                quick.classList.add("white-box");
+                quick.classList.add("quick-summary-collapsed");
+                quick.style.marginBottom = "10px";
+                quick.style.padding = "12px";
+                quick.style.maxHeight = "0";
                 showFullDetails();
                 if (clientLabel && clientBox) { clientLabel.style.display = "none"; clientBox.style.display = "none"; }
                 if (billingLabel && billingBox) { billingLabel.style.display = "none"; billingBox.style.display = "none"; }

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -275,7 +275,8 @@
     transition: max-height 0.3s ease;
 }
 
-#copilot-sidebar .white-box.quick-summary-content {
+#copilot-sidebar .white-box.quick-summary-content,
+#copilot-sidebar .quick-summary-content {
     font-size: 13px;
     line-height: 1.4em;
 }


### PR DESCRIPTION
## Summary
- merge quick summary into ORDER SUMMARY box when Gmail Review Mode is on
- document new behavior in the README
- support styling for quick summary when not inside a white box

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68574cb037488326a8ed4516bf89c83b