### PR TITLE
Add Adyen DNA info parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ information scraped from the current page.
   mode stays in sync across Gmail and DB.
 - The Adyen helper now waits for the shopper DNA link to appear before opening
   it so slow pages still navigate correctly.
+- When both the Payment details and Shopper DNA pages finish loading, their
+  information is collected and shown in a new **ADYEN'S DNA** section of the
+  Gmail sidebar.
 
 ### DB
 - Displays a sidebar on order detail pages.


### PR DESCRIPTION
## Summary
- parse payment and transaction data on Adyen pages
- surface collected info in Gmail sidebar under new **ADYEN'S DNA** section
- document new DNA section in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857538034ec8326b0c89dcfb523e734