### PR TITLE
Fix Gmail DNA button hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Reload the extension after editing the manifest.
   - Fixed Review Mode setting so Gmail and DB pages stay synchronized.
 - Fixed popup Review Mode toggle to use sync storage so the DNA button appears after enabling the mode.
 - Fixed DNA button not appearing in Gmail Review Mode by storing the setting locally.
+- Fixed the DNA summary replacing the button in Gmail Review Mode so the button remains visible when no data is available.
 - Escaped quotes in the background script so the service worker loads correctly.
   Buttons like **EMAIL SEARCH** and **OPEN ORDER** now open tabs again.
 - Common helpers moved to `core/utils.js` and shared by Gmail and DB scripts.

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -697,7 +697,7 @@
         }
 
         function loadDnaSummary() {
-            const container = document.querySelector('.copilot-dna');
+            const container = document.getElementById('dna-summary');
             if (!container) return;
             chrome.storage.local.get({ adyenDnaInfo: null }, ({ adyenDnaInfo }) => {
                 const html = buildDnaHtml(adyenDnaInfo);
@@ -840,7 +840,9 @@
                         <button id="btn-email-search" class="copilot-button">📧 EMAIL SEARCH</button>
                         <button id="btn-open-order" class="copilot-button">📂 OPEN ORDER</button>
                     </div>
-                    <div class="copilot-dna"></div>
+                    <div class="copilot-dna">
+                        <div id="dna-summary" style="margin-top:6px"></div>
+                    </div>
                     <div class="section-label" style="margin:6px 0">COMPANY:</div>
                     <div class="order-summary-header">ORDER SUMMARY</div>
                     <div class="order-summary-box">


### PR DESCRIPTION
## Summary
- keep DNA button when loading summary in Gmail Review Mode
- document fix in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685759f088248326a01a42386367d48f