### PR TITLE
Fix DNA summary visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,4 +320,6 @@ Reload the extension after editing the manifest.
   Family Tree icon works consistently.
 - Fixed EMAIL SEARCH removing the DNA button by keeping the summary container
   intact while loading.
+- The DNA summary now stays hidden until Adyen data is available and is
+  displayed below the Billing section in Gmail Review Mode.
 

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -657,6 +657,17 @@
                     container.innerHTML = '<div style="text-align:center; color:#aaa; font-size:13px;">No DB data.</div>';
                     storedOrderInfo = null;
                 }
+
+                const dna = document.getElementById('dna-summary');
+                if (dna) {
+                    const billing = container.querySelector('#billing-section-box');
+                    if (billing && billing.parentElement) {
+                        billing.parentElement.insertAdjacentElement('afterend', dna);
+                    } else {
+                        container.appendChild(dna);
+                    }
+                }
+
                 updateDetailVisibility();
             });
         }
@@ -704,7 +715,7 @@
                 if (html) {
                     container.innerHTML = html;
                 } else {
-                    container.innerHTML = '<div style="text-align:center; color:#aaa; font-size:13px;">No DNA data.</div>';
+                    container.innerHTML = '';
                 }
                 attachCommonListeners(container);
             });
@@ -773,7 +784,7 @@
                     summary.style.marginTop = '6px';
                     dnaBox.appendChild(summary);
                 }
-                summary.innerHTML = icon;
+                summary.innerHTML = '';
             }
             if (issueLabel) {
                 issueLabel.textContent = '';

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -59,6 +59,10 @@
     margin-top: 8px;
 }
 
+#dna-summary:empty {
+    display: none;
+}
+
 .copilot-dna .copilot-button {
     width: 100%;
 }

--- a/styles/sidebar_bento.css
+++ b/styles/sidebar_bento.css
@@ -48,6 +48,10 @@
     box-shadow: 0 4px 6px rgba(0,0,0,0.2);
 }
 
+#dna-summary:empty {
+    display: none;
+}
+
 .fennec-bento-mode .copilot-body {
     display: grid;
     grid-template-columns: 1fr 1fr;

--- a/styles/sidebar_light.css
+++ b/styles/sidebar_light.css
@@ -42,6 +42,10 @@
     color: #fff !important;
 }
 
+#dna-summary:empty {
+    display: none;
+}
+
 /* Ensure status labels remain visible */
 .fennec-light-mode #copilot-sidebar .issue-status-label,
 .fennec-light-mode #copilot-sidebar .review-mode-label {


### PR DESCRIPTION
## Summary
- move DNA summary below Billing section
- hide DNA placeholder until data exists
- hide loading icon above DNA button
- note updated behavior in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68575fce855083268e844259d9884a19