### PR TITLE
Add looping video background for Bento mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ information scraped from the current page.
 4. Click **Load unpacked** and select the project folder. The sidebar will then
    be available when visiting supported pages.
 5. Use the extension popup to enable **Light Mode** for a minimalist black and white style. Summary text is solid black with medium gray borders, the header shows white text on a black bar and the Fennec icon appears inverted.
-6. Enable **Bento Mode** from the popup to switch the sidebar to a colorful grid layout with animated backgrounds and subtle hover effects.
+6. Enable **Bento Mode** from the popup to switch the sidebar to a colorful grid layout with a looping video background and subtle hover effects.
 7. Open the extension **Options** from the menu or the Extensions page to set a default sidebar width and Review Mode.
 
 ## Features
 
 - Sidebar appears on Gmail and DB order pages.
 - Quick buttons open Gmail searches and order pages.
-- Light Mode and Bento Mode offer alternative layouts.
+- Light Mode offers a minimalist look and Bento Mode adds a holographic video background.
 - Family Tree panel shows related orders and can diagnose holds.
 - Review Mode merges order details and fetches Adyen DNA data.
 - The DNA summary is inserted below the Billing section once data is available.

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -39,6 +39,6 @@ NOTES
 ADDITIONAL FEATURES
 ────────────────────────────
 
-Bento Mode → Colorful grid layout with animated backgrounds for the sidebar
+Bento Mode → Colorful grid layout with looping video background for the sidebar
 Light Mode → Minimalist black-on-white style with an inverted Fennec icon
 DNA        → Shortcut button that opens Adyen payment details and shopper DNA

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -430,6 +430,23 @@
                         </div>
                     `;
                     document.body.appendChild(sidebar);
+                    if (document.body.classList.contains('fennec-bento-mode')) {
+                        const vid = document.createElement('video');
+                        vid.id = 'bento-video';
+                        vid.src = chrome.runtime.getURL('BG_HOLO.mp4');
+                        vid.muted = true;
+                        vid.autoplay = true;
+                        vid.playsInline = true;
+                        vid.loop = false;
+                        sidebar.prepend(vid);
+                        let reverse = false;
+                        vid.addEventListener('ended', () => {
+                            reverse = !reverse;
+                            vid.playbackRate = reverse ? -1 : 1;
+                            vid.currentTime = reverse ? vid.duration - 0.01 : 0.01;
+                            vid.play();
+                        });
+                    }
                     updateReviewDisplay();
                     const closeBtn = sidebar.querySelector('#copilot-close');
                     if (closeBtn) {

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -897,6 +897,23 @@
                 </div>
             `;
             document.body.appendChild(sidebar);
+            if (document.body.classList.contains('fennec-bento-mode')) {
+                const vid = document.createElement('video');
+                vid.id = 'bento-video';
+                vid.src = chrome.runtime.getURL('BG_HOLO.mp4');
+                vid.muted = true;
+                vid.autoplay = true;
+                vid.playsInline = true;
+                vid.loop = false;
+                sidebar.prepend(vid);
+                let reverse = false;
+                vid.addEventListener('ended', () => {
+                    reverse = !reverse;
+                    vid.playbackRate = reverse ? -1 : 1;
+                    vid.currentTime = reverse ? vid.duration - 0.01 : 0.01;
+                    vid.play();
+                });
+            }
             console.log("[Copilot] Sidebar INYECTADO en Gmail.");
 
             // Start with empty boxes. Details load after the user interacts

--- a/styles/sidebar_bento.css
+++ b/styles/sidebar_bento.css
@@ -14,32 +14,44 @@
 }
 
 .fennec-bento-mode #copilot-sidebar {
-    background: linear-gradient(120deg,
-        #ff9a9e,
-        #fad0c4,
-        #fbc2eb,
-        #a6c1ee);
-    background-size: 300% 300%;
-    animation: bento-gradient 12s ease infinite;
-    color: #222;
+    position: relative;
+    overflow: hidden;
+    background: #000;
+    color: #fff;
     font-family: "Segoe UI", Arial, sans-serif;
 }
 
+.fennec-bento-mode #bento-video {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.fennec-bento-mode #copilot-sidebar > * {
+    position: relative;
+    z-index: 1;
+}
+
 .fennec-bento-mode .copilot-header {
-    background: rgba(255, 255, 255, 0.6);
+    background: rgba(0, 0, 0, 0.6);
     backdrop-filter: blur(8px);
-    color: #000;
+    color: #fff;
     border-bottom: none;
-    box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+    box-shadow: 0 1px 4px rgba(0,0,0,0.3);
 }
 
 .fennec-bento-mode .copilot-button {
-    background-color: rgba(255, 255, 255, 0.8);
-    color: #333;
+    background-color: rgba(0, 0, 0, 0.6);
+    color: #fff;
     border: none;
     border-radius: 8px;
     padding: 6px 12px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    box-shadow: 0 2px 4px rgba(0,0,0,0.3);
     transition: transform 0.2s, box-shadow 0.2s;
 }
 
@@ -67,12 +79,12 @@
 .fennec-bento-mode .intel-summary-box,
 .fennec-bento-mode .issue-summary-box,
 .fennec-bento-mode #copilot-sidebar .white-box {
-    background: rgba(255, 255, 255, 0.9);
+    background: rgba(0, 0, 0, 0.65);
     border: none;
-    color: #222;
+    color: #fff;
     border-radius: 10px;
     padding: 10px;
-    box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+    box-shadow: 0 1px 4px rgba(0,0,0,0.3);
     transition: transform 0.2s;
 }
 


### PR DESCRIPTION
## Summary
- use BG_HOLO.mp4 as Bento Mode background
- darken Bento colors and make summary boxes transparent
- loop video forward and backward on Gmail and DB pages
- document the new background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685776acd41083268db3d6415310f1dd