### PR TITLE
Fix Bento Mode sidebar visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.3
 
+- Fixed Bento Mode positioning so the sidebar displays correctly on Gmail and DB.
 - Fixed a race condition where the "Family Tree" view failed to load if the
   background script queried the page before helper functions finished
   initializing.

--- a/manifest.json
+++ b/manifest.json
@@ -72,7 +72,8 @@
   "web_accessible_resources": [
     {
       "resources": [
-        "fennec_icon.png"
+        "fennec_icon.png",
+        "BG_HOLO.mp4"
       ],
       "matches": [
         "<all_urls>"

--- a/styles/sidebar_bento.css
+++ b/styles/sidebar_bento.css
@@ -14,7 +14,7 @@
 }
 
 .fennec-bento-mode #copilot-sidebar {
-    position: relative;
+    position: fixed;
     overflow: hidden;
     background: #000;
     color: #fff;


### PR DESCRIPTION
## Summary
- keep sidebar fixed in Bento Mode
- expose BG_HOLO.mp4 to pages
- note fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685778f899508326aad65aa32e5b7825