### PR TITLE
Fix Bento overlay styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ information scraped from the current page.
 
 - Sidebar appears on Gmail and DB order pages.
 - Quick buttons open Gmail searches and order pages.
-- Light Mode offers a minimalist look and Bento Mode adds a holographic video background.
+- Light Mode offers a minimalist look.
+- Bento Mode uses a holographic video background and displays all headers and
+  summary boxes in black containers with 95% opacity and white text.
 - Family Tree panel shows related orders and can diagnose holds.
 - Review Mode merges order details and fetches Adyen DNA data.
 - The DNA summary is inserted below the Billing section once data is available.

--- a/styles/sidebar_bento.css
+++ b/styles/sidebar_bento.css
@@ -38,7 +38,9 @@
 }
 
 .fennec-bento-mode .copilot-header {
-    background: rgba(0, 0, 0, 0.6);
+    position: relative;
+    z-index: 2;
+    background: rgba(0, 0, 0, 0.95);
     backdrop-filter: blur(8px);
     color: #fff;
     border-bottom: none;
@@ -46,7 +48,7 @@
 }
 
 .fennec-bento-mode .copilot-button {
-    background-color: rgba(0, 0, 0, 0.6);
+    background-color: rgba(0, 0, 0, 0.95);
     color: #fff;
     border: none;
     border-radius: 8px;
@@ -79,7 +81,7 @@
 .fennec-bento-mode .intel-summary-box,
 .fennec-bento-mode .issue-summary-box,
 .fennec-bento-mode #copilot-sidebar .white-box {
-    background: rgba(0, 0, 0, 0.65);
+    background: rgba(0, 0, 0, 0.95);
     border: none;
     color: #fff;
     border-radius: 10px;


### PR DESCRIPTION
## Summary
- ensure Bento header and containers appear above the background video
- use nearly opaque black for Bento containers
- clarify Bento Mode styling in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68577ad316a083268519e59b641d57fd