### PR TITLE
Fix Bento Mode layering in sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.3
 
 - Fixed Bento Mode positioning so the sidebar displays correctly on Gmail and DB.
+- Fixed Bento Mode layering so headers and boxes appear above the video background.
 - Fixed a race condition where the "Family Tree" view failed to load if the
   background script queried the page before helper functions finished
   initializing.

--- a/styles/sidebar_bento.css
+++ b/styles/sidebar_bento.css
@@ -21,7 +21,7 @@
     font-family: "Segoe UI", Arial, sans-serif;
 }
 
-.fennec-bento-mode #bento-video {
+.fennec-bento-mode #copilot-sidebar #bento-video {
     position: absolute;
     top: 0;
     left: 0;


### PR DESCRIPTION
## Summary
- keep video behind the sidebar content so headers and containers are visible
- note Bento Mode layering fix in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68577e20710c8326a8075872d5aab0a0