### PR TITLE
Fix DNA background search

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ information scraped from the current page.
 - Family Tree panel shows related orders and can diagnose holds.
 - Review Mode merges order details and fetches Adyen DNA data.
 - The DNA summary is inserted below the Billing section once data is available.
- - Adyen payment details open in the background and automatically navigate to the DNA page after collecting information. Network transactions from the DNA page are captured.
+ - Adyen payment details open in the background and automatically navigate to the DNA page after collecting information. The search now runs even if the tab stays in the background, and network transactions from the DNA page are captured.
 - A Refresh button updates information without reloading the page.
 
 See [CHANGELOG.md](CHANGELOG.md) for a detailed list of bug fixes.

--- a/core/background_emailsearch.js
+++ b/core/background_emailsearch.js
@@ -11,6 +11,16 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         chrome.tabs.create(opts, (tab) => {
             if (chrome.runtime.lastError) {
                 console.error("[Copilot] Error (openTab):", chrome.runtime.lastError.message);
+                return;
+            }
+            if (message.runAdyen) {
+                const listener = (tabId, info) => {
+                    if (tabId === tab.id && info.status === "complete") {
+                        chrome.tabs.onUpdated.removeListener(listener);
+                        chrome.tabs.sendMessage(tabId, { action: "startAdyenFlow" });
+                    }
+                };
+                chrome.tabs.onUpdated.addListener(listener);
             }
         });
     }

--- a/environments/adyen/adyen_launcher.js
+++ b/environments/adyen/adyen_launcher.js
@@ -55,6 +55,12 @@
                 });
             }
 
+            chrome.runtime.onMessage.addListener((msg) => {
+                if (msg.action === 'startAdyenFlow') {
+                    fillAndSubmit();
+                }
+            });
+
             function openMostRecent() {
                 waitForElement('a[href*="showTx.shtml?pspReference="]').then(link => {
                     try {

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -1044,7 +1044,7 @@
                     console.log('[Copilot] Opening Adyen for order', orderId);
                     const url = `https://ca-live.adyen.com/ca/ca/overview/default.shtml?fennec_order=${orderId}`;
                     showDnaLoading();
-                    chrome.runtime.sendMessage({ action: "openTab", url });
+                    chrome.runtime.sendMessage({ action: "openTab", url, runAdyen: true });
                 } catch (error) {
                     console.error("Error al intentar buscar en Adyen:", error);
                     alert("Ocurrió un error al intentar buscar en Adyen.");


### PR DESCRIPTION
## Summary
- trigger DNA search after tab loads by messaging Adyen page
- listen for `startAdyenFlow` inside Adyen launcher
- request background search from Gmail when opening Adyen tab
- document that the DNA search works even if the tab never activates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68598909e00c83269752d9bcf5ab11b4