### PR TITLE
Improve DNA search reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,3 +71,4 @@
   displayed below the Billing section in Gmail Review Mode.
  - Adyen opens the Payment Details tab in the background and then automatically navigates to the DNA page to capture transactions.
  - The Adyen search now starts even if the tab never becomes active so DNA data loads without switching tabs.
+- Improved DNA reliability by retrying the background search until the page finishes loading.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ information scraped from the current page.
 - Family Tree panel shows related orders and can diagnose holds.
 - Review Mode merges order details and fetches Adyen DNA data.
 - The DNA summary is inserted below the Billing section once data is available.
- - Adyen payment details open in the background and automatically navigate to the DNA page after collecting information. The search now runs even if the tab stays in the background, and network transactions from the DNA page are captured.
+- Adyen payment details open in the background and automatically navigate to the DNA page after collecting information. The search now runs even if the tab stays in the background and retries a few times so DNA data loads without switching tabs. Network transactions from the DNA page are captured.
 - A Refresh button updates information without reloading the page.
 
 See [CHANGELOG.md](CHANGELOG.md) for a detailed list of bug fixes.

--- a/core/background_emailsearch.js
+++ b/core/background_emailsearch.js
@@ -14,12 +14,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 return;
             }
             if (message.runAdyen) {
-                let sent = false;
+                let attempts = 5;
                 const send = () => {
-                    if (!sent) {
-                        sent = true;
-                        chrome.tabs.sendMessage(tab.id, { action: "startAdyenFlow" });
-                    }
+                    chrome.tabs.sendMessage(tab.id, { action: "startAdyenFlow" }, () => {
+                        if (chrome.runtime.lastError && --attempts > 0) {
+                            setTimeout(send, 2000);
+                        }
+                    });
                 };
                 const listener = (tabId, info) => {
                     if (tabId === tab.id && info.status === "complete") {


### PR DESCRIPTION
## Summary
- retry sending `startAdyenFlow` when opening Adyen tabs so the search kicks off without switching tabs
- document retry behavior
- note the change in the changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68598e47efb48326b32edc9d3eeaaffb