### PR TITLE
Fix Adyen search timing

### DIFF
--- a/core/background_emailsearch.js
+++ b/core/background_emailsearch.js
@@ -16,10 +16,14 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             }
             if (message.runAdyen) {
                 let attempts = 5;
+                let returned = false;
                 const send = () => {
                     chrome.tabs.sendMessage(tab.id, { action: "startAdyenFlow" }, () => {
                         if (chrome.runtime.lastError && --attempts > 0) {
                             setTimeout(send, 2000);
+                        } else if (previousTabId && !returned) {
+                            chrome.tabs.update(previousTabId, { active: true });
+                            returned = true;
                         }
                     });
                 };
@@ -31,11 +35,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 };
                 chrome.tabs.onUpdated.addListener(listener);
                 setTimeout(send, 5000);
-                if (previousTabId) {
-                    setTimeout(() => {
-                        chrome.tabs.update(previousTabId, { active: true });
-                    }, 1000);
-                }
             }
         });
     }


### PR DESCRIPTION
## Summary
- wait until the new tab receives the `startAdyenFlow` message before switching back to Gmail

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859923ccecc832691edcf5d49aadb3e