### PR TITLE
Fix DNA summary persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,3 +73,4 @@
  - The Adyen search now starts even if the tab never becomes active so DNA data loads without switching tabs.
 - Improved DNA reliability by retrying the background search until the page finishes loading.
 - The DNA search now waits up to 20 seconds for Adyen elements to load.
+- DNA results are stored with the order ID so returning to Gmail shows the summary again.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ information scraped from the current page.
 - The DNA summary is inserted below the Billing section once data is available.
 - Adyen payment details briefly take focus to ensure the search begins, then automatically return to Gmail. The Payment Details tab navigates to the DNA page after collecting information and retries the search so DNA data loads without manual tab switching. Network transactions from the DNA page are captured.
 - The DNA search now waits up to 20 seconds for Adyen elements to load.
+- DNA summaries persist after switching tabs and reappear when returning to the same order.
 - A Refresh button updates information without reloading the page.
 
 See [CHANGELOG.md](CHANGELOG.md) for a detailed list of bug fixes.

--- a/environments/adyen/adyen_launcher.js
+++ b/environments/adyen/adyen_launcher.js
@@ -77,7 +77,7 @@
 
             function saveData(part) {
                 chrome.storage.local.get({ adyenDnaInfo: {} }, ({ adyenDnaInfo }) => {
-                    const updated = Object.assign({}, adyenDnaInfo, part);
+                    const updated = Object.assign({}, adyenDnaInfo, part, { order });
                     chrome.storage.local.set({ adyenDnaInfo: updated });
                     console.log('[FENNEC Adyen] Data saved', part);
                 });

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -713,12 +713,16 @@
             return `<div class="section-label">ADYEN'S DNA</div><div class="white-box" style="margin-bottom:10px">${parts.join('')}</div>`;
         }
 
-       function loadDnaSummary() {
-           const container = document.getElementById('dna-summary');
-           if (!container) return;
+        function loadDnaSummary() {
+            const container = document.getElementById('dna-summary');
+            if (!container) return;
             console.log('[Copilot] Loading DNA summary');
             console.log('[Copilot] Fetching DNA info from storage');
+            const orderId = currentContext && currentContext.orderNumber;
             chrome.storage.local.get({ adyenDnaInfo: null }, ({ adyenDnaInfo }) => {
+                if (adyenDnaInfo && orderId && adyenDnaInfo.order !== orderId) {
+                    adyenDnaInfo = null;
+                }
                 const html = buildDnaHtml(adyenDnaInfo);
                 if (html) {
                     console.log('[Copilot] DNA data found');
@@ -776,7 +780,7 @@
             });
         }
 
-        function showDnaLoading() {
+        function showDnaLoading(orderId) {
             const dnaBox = document.querySelector('.copilot-dna');
             if (!dnaBox) return;
             let summary = dnaBox.querySelector('#dna-summary');
@@ -788,7 +792,9 @@
             }
             summary.innerHTML = `<img src="${chrome.runtime.getURL('fennec_icon.png')}" class="loading-fennec"/>`;
             console.log('[Copilot] Showing DNA loading placeholder');
-            chrome.storage.local.set({ adyenDnaInfo: null });
+            if (orderId) {
+                chrome.storage.local.set({ adyenDnaInfo: { order: orderId } });
+            }
             repositionDnaSummary();
         }
 
@@ -1049,7 +1055,7 @@
                     console.log('[Copilot] DNA button clicked for order', orderId);
                     console.log('[Copilot] Opening Adyen for order', orderId);
                     const url = `https://ca-live.adyen.com/ca/ca/overview/default.shtml?fennec_order=${orderId}`;
-                    showDnaLoading();
+                    showDnaLoading(orderId);
                     chrome.runtime.sendMessage({ action: "openTab", url, runAdyen: true });
                 } catch (error) {
                     console.error("Error al intentar buscar en Adyen:", error);


### PR DESCRIPTION
## Summary
- retain Adyen DNA info until new data is fetched
- store the associated order ID in `adyenDnaInfo`
- reload DNA summary only when the stored ID matches the current order
- document behaviour in README and CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68599902d1b0832687c3f3c912080485