### PR TITLE
Show formation date with state ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v0.3 - 2025-06-24
+- Added Date of Formation next to the State ID in the Company summary on DB and Gmail sidebars.
 
 - Fixed Bento Mode positioning so the sidebar displays correctly on Gmail and DB.
 - Fixed Bento Mode layering so headers and boxes appear above the video background.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ information scraped from the current page.
 - CODA Search menu item queries the knowledge base using the Coda API.
 - Clicking the state in the DB sidebar now opens the Coda Knowledge Base in a popup window covering about 70% of the page.
 - Clicking the company name or State ID opens the state's SOS search page directly without requesting extra permissions.
+- The Date of Formation appears next to the State ID in the Company summary.
 - Edit `environments/db/db_launcher.js` to provide your Coda API token and the
   Coda doc ID. Generate a new token in Coda and replace the value after
   `Bearer` if searches return "No results". Set the doc ID without the leading

--- a/environments/db/db_launcher.js
+++ b/environments/db/db_launcher.js
@@ -1088,6 +1088,7 @@
             {name: 'name', label: 'company name'},
             {name: 'stateId', label: 'state id'},
             {name: 'state', label: 'state of formation'},
+            {name: 'formationDate', label: 'date of formation'},
             {name: 'status', label: 'state status'},
             {name: 'purpose', label: 'purpose'},
             {name: 'street', label: 'street'},
@@ -1133,6 +1134,9 @@
             name: companyRaw.name,
             stateId: companyRaw.stateId,
             state: companyRaw.state,
+            formationDate: companyRaw.formationDate && !/n\/?a/i.test(companyRaw.formationDate)
+                ? formatDateLikeParent(companyRaw.formationDate)
+                : null,
             status: companyRaw.status || headerStatus,
             purpose: companyRaw.purpose,
             address: buildAddress(companyRaw),
@@ -1504,6 +1508,9 @@
                 } else {
                     idHtml += ' ' + renderCopyIcon(company.stateId);
                 }
+                if (company.formationDate) {
+                    idHtml += ` \u2022 ${escapeHtml(company.formationDate)}`;
+                }
                 companyLines.push(`<div>${idHtml}</div>`);
             }
             companyLines.push(`<div>${renderKb(company.state)}</div>`);
@@ -1644,7 +1651,8 @@
             expedited: isExpeditedOrder(),
             companyName: company ? company.name : null,
             companyId: company ? company.stateId : null,
-            companyState: company ? company.state : null
+            companyState: company ? company.state : null,
+            formationDate: company ? company.formationDate : null
         };
         chrome.storage.local.set({
             sidebarDb: dbSections,

--- a/environments/gmail/gmail_launcher.js
+++ b/environments/gmail/gmail_launcher.js
@@ -688,7 +688,11 @@
                     const idBase = buildSosUrl(storedOrderInfo.companyState, null, 'id');
                     const compId = escapeHtml(storedOrderInfo.companyId);
                     const idLink = idBase ? `<a href="#" class="copilot-sos copilot-link" data-url="${idBase}" data-query="${compId}" data-type="id">${compId}</a>` : compId;
-                    html += `<div>${idLink} ${renderCopyIcon(storedOrderInfo.companyId)}</div>`;
+                    let line = `${idLink} ${renderCopyIcon(storedOrderInfo.companyId)}`;
+                    if (storedOrderInfo.formationDate) {
+                        line += ` \u2022 ${escapeHtml(storedOrderInfo.formationDate)}`;
+                    }
+                    html += `<div>${line}</div>`;
                 }
             }
             if (orderId) html += `<div><b><a href="#" id="order-link" class="order-link">${renderCopy(orderId)}</a> ${renderCopyIcon(orderId)}</b></div>`;


### PR DESCRIPTION
## Summary
- extract Date of Formation from DB orders
- display formation date next to the State ID in the Company section
- expose formation date in stored order info so Gmail sidebar shows it too
- document feature in README and CHANGELOG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c287146108326af7adc7e359afc50